### PR TITLE
Change HIDPowerDevice_  to inherit from HID_ instead of aggregating it

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -65,36 +65,36 @@ void setup() {
   pinMode(COMMLOSTPIN, OUTPUT); // output is on once communication is lost with the host, otherwise off.
 
 
-  PowerDevice.setFeature(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
+  PowerDevice.SetFeature(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
   
-  PowerDevice.setFeature(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
-  PowerDevice.setFeature(HID_PD_AVERAGETIME2FULL, &iAvgTimeToFull, sizeof(iAvgTimeToFull));
-  PowerDevice.setFeature(HID_PD_AVERAGETIME2EMPTY, &iAvgTimeToEmpty, sizeof(iAvgTimeToEmpty));
-  PowerDevice.setFeature(HID_PD_REMAINTIMELIMIT, &iRemainTimeLimit, sizeof(iRemainTimeLimit));
-  PowerDevice.setFeature(HID_PD_DELAYBE4REBOOT, &iDelayBe4Reboot, sizeof(iDelayBe4Reboot));
-  PowerDevice.setFeature(HID_PD_DELAYBE4SHUTDOWN, &iDelayBe4ShutDown, sizeof(iDelayBe4ShutDown));
+  PowerDevice.SetFeature(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
+  PowerDevice.SetFeature(HID_PD_AVERAGETIME2FULL, &iAvgTimeToFull, sizeof(iAvgTimeToFull));
+  PowerDevice.SetFeature(HID_PD_AVERAGETIME2EMPTY, &iAvgTimeToEmpty, sizeof(iAvgTimeToEmpty));
+  PowerDevice.SetFeature(HID_PD_REMAINTIMELIMIT, &iRemainTimeLimit, sizeof(iRemainTimeLimit));
+  PowerDevice.SetFeature(HID_PD_DELAYBE4REBOOT, &iDelayBe4Reboot, sizeof(iDelayBe4Reboot));
+  PowerDevice.SetFeature(HID_PD_DELAYBE4SHUTDOWN, &iDelayBe4ShutDown, sizeof(iDelayBe4ShutDown));
   
-  PowerDevice.setFeature(HID_PD_RECHARGEABLE, &bRechargable, sizeof(bRechargable));
-  PowerDevice.setFeature(HID_PD_CAPACITYMODE, &bCapacityMode, sizeof(bCapacityMode));
-  PowerDevice.setFeature(HID_PD_CONFIGVOLTAGE, &iConfigVoltage, sizeof(iConfigVoltage));
-  PowerDevice.setFeature(HID_PD_VOLTAGE, &iVoltage, sizeof(iVoltage));
+  PowerDevice.SetFeature(HID_PD_RECHARGEABLE, &bRechargable, sizeof(bRechargable));
+  PowerDevice.SetFeature(HID_PD_CAPACITYMODE, &bCapacityMode, sizeof(bCapacityMode));
+  PowerDevice.SetFeature(HID_PD_CONFIGVOLTAGE, &iConfigVoltage, sizeof(iConfigVoltage));
+  PowerDevice.SetFeature(HID_PD_VOLTAGE, &iVoltage, sizeof(iVoltage));
 
   PowerDevice.setStringFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
   PowerDevice.setStringFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
 
-  PowerDevice.setFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
+  PowerDevice.SetFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
 
-  PowerDevice.setFeature(HID_PD_DESIGNCAPACITY, &iDesignCapacity, sizeof(iDesignCapacity));
-  PowerDevice.setFeature(HID_PD_FULLCHRGECAPACITY, &iFullChargeCapacity, sizeof(iFullChargeCapacity));
-  PowerDevice.setFeature(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
-  PowerDevice.setFeature(HID_PD_WARNCAPACITYLIMIT, &iWarnCapacityLimit, sizeof(iWarnCapacityLimit));
-  PowerDevice.setFeature(HID_PD_REMNCAPACITYLIMIT, &iRemnCapacityLimit, sizeof(iRemnCapacityLimit));
-  PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
-  PowerDevice.setFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
+  PowerDevice.SetFeature(HID_PD_DESIGNCAPACITY, &iDesignCapacity, sizeof(iDesignCapacity));
+  PowerDevice.SetFeature(HID_PD_FULLCHRGECAPACITY, &iFullChargeCapacity, sizeof(iFullChargeCapacity));
+  PowerDevice.SetFeature(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
+  PowerDevice.SetFeature(HID_PD_WARNCAPACITYLIMIT, &iWarnCapacityLimit, sizeof(iWarnCapacityLimit));
+  PowerDevice.SetFeature(HID_PD_REMNCAPACITYLIMIT, &iRemnCapacityLimit, sizeof(iRemnCapacityLimit));
+  PowerDevice.SetFeature(HID_PD_CPCTYGRANULARITY1, &bCapacityGranularity1, sizeof(bCapacityGranularity1));
+  PowerDevice.SetFeature(HID_PD_CPCTYGRANULARITY2, &bCapacityGranularity2, sizeof(bCapacityGranularity2));
 
   uint16_t year = 2024, month = 10, day = 12;
   iManufacturerDate = (year - 1980)*512 + month*32 + day; // from 4.2.6 Battery Settings in "Universal Serial Bus Usage Tables for HID Power Devices"
-  PowerDevice.setFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
+  PowerDevice.SetFeature(HID_PD_MANUFACTUREDATE, &iManufacturerDate, sizeof(iManufacturerDate));
 }
 
 void loop() {
@@ -166,9 +166,9 @@ void loop() {
 
   if((iPresentStatus != iPreviousStatus) || (iRemaining != iPrevRemaining) || (iRunTimeToEmpty != iPrevRunTimeToEmpty) || (iIntTimer>MINUPDATEINTERVAL) ) {
 
-    PowerDevice.sendReport(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
-    if(bDischarging) PowerDevice.sendReport(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
-    iRes = PowerDevice.sendReport(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
+    PowerDevice.SendReport(HID_PD_REMAININGCAPACITY, &iRemaining, sizeof(iRemaining));
+    if(bDischarging) PowerDevice.SendReport(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
+    iRes = PowerDevice.SendReport(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
 
     if(iRes <0 ) {
       digitalWrite(COMMLOSTPIN, HIGH);

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -21,12 +21,6 @@
 
 #if defined(USBCON)
 
-HID_& HID()
-{
-    static HID_ obj;
-    return obj;
-}
-
 int HID_::getInterface(uint8_t* interfaceCount)
 {
     *interfaceCount += 1; // uses 1

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -157,11 +157,6 @@ private:
     
 };
 
-// Replacement for global singleton.
-// This function prevents static-initialization-order-fiasco
-// https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
-HID_& HID();
-
 #define D_HIDREPORT(length) { 9, 0x21, 0x01, 0x01, 0x21, 1, 0x22, lowByte(length), highByte(length) }
 
 #endif // USBCON

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -224,26 +224,18 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
 HIDPowerDevice_::HIDPowerDevice_(void) {
     static HIDSubDescriptor node(_hidReportDescriptor, sizeof (_hidReportDescriptor));
 
-    HID().AppendDescriptor(&node);
+    AppendDescriptor(&node);
 }
 
 void HIDPowerDevice_::begin(void) {
-    HID().begin();
+    HID_::begin();
     
     // set string ID here
     
-    HID().SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
-    HID().SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
-    HID().SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
+    SetFeature(HID_PD_IPRODUCT, &bProduct, sizeof(bProduct));
+    SetFeature(HID_PD_SERIAL, &bSerial, sizeof(bSerial));
+    SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
     
-}
-
-void HIDPowerDevice_::setOutput(Serial_& out) {
-    HID().setOutput(out);
-}
-
-void HIDPowerDevice_::setSerial(const char* s) {
-    HID().setSerial(s);
 }
 
 void HIDPowerDevice_::end(void) {
@@ -251,24 +243,16 @@ void HIDPowerDevice_::end(void) {
 
 int HIDPowerDevice_::sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day) {
     uint16_t bval = (year - 1980)*512 + month * 32 + day;
-    return HID().SendReport(id, &bval, sizeof (bval));
-}
-
-int HIDPowerDevice_::sendReport(uint16_t id, const void* bval, int len) {
-    return HID().SendReport(id, bval, len);
-}
-
-int HIDPowerDevice_::setFeature(uint16_t id, const void *data, int len) {
-    return HID().SetFeature(id, data, len);
+    return SendReport(id, &bval, sizeof (bval));
 }
 
 int HIDPowerDevice_::setStringFeature(uint8_t id, const uint8_t* index, const char* data) {
     
-    int res = HID().SetFeature(id, index, 1);
+    int res = SetFeature(id, index, 1);
     
     if(res == 0) return 0;
     
-    res += HID().SetFeature(0xFF00 | *index , data, strlen_P(data));
+    res += SetFeature(0xFF00 | *index , data, strlen_P(data));
     
     return res;
 }

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -102,7 +102,7 @@ static_assert(sizeof(PresentStatus) == sizeof(uint16_t));
 
 
 
-class HIDPowerDevice_  {
+class HIDPowerDevice_ : public HID_ {
     
 private:
     
@@ -114,20 +114,11 @@ public:
   HIDPowerDevice_(void);
   void begin(void);
   
-  void setOutput(Serial_&);
-  
-  void setSerial(const char*);
-  
-  
   void end(void);
   
   int sendDate(uint16_t id, uint16_t year, uint8_t month, uint8_t day);
-  int sendReport(uint16_t id, const void* bval, int len);
-  
-  int setFeature(uint16_t id, const void* data, int len);
   
   int setStringFeature(uint8_t id, const uint8_t* index, const char* data);
-
 };
 
 extern HIDPowerDevice_ PowerDevice;


### PR DESCRIPTION
Preparation to better support multi-battery setups where a global HID singleton no longer makes sense. This also simplifies the HIDPowerDevice_ class by removing wrapper methods that just forwards the call to the underlying HID_ class.