### PR TITLE
HID: Replace manual defines with pluggedEndpoint member

### DIFF
--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -33,7 +33,7 @@ int HID_::getInterface(uint8_t* interfaceCount)
     HIDDescriptor hidInterface = {
         D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
         D_HIDREPORT(descriptorSize),
-        D_ENDPOINT(USB_ENDPOINT_IN(HID_TX), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14)
+        D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x14)
     };
     return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
@@ -167,9 +167,9 @@ bool HID_::LockFeature(uint16_t id, bool lock) {
 
 int HID_::SendReport(uint16_t id, const void* data, int len)
 {
-    auto ret = USB_Send(HID_TX, &id, 1);
+    auto ret = USB_Send(pluggedEndpoint, &id, 1);
     if (ret < 0) return ret;
-    auto ret2 = USB_Send(HID_TX | TRANSFER_RELEASE, data, len);
+    auto ret2 = USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, len);
     if (ret2 < 0) return ret2;
     return ret + ret2;
 }

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -61,14 +61,6 @@
 #define HID_REPORT_TYPE_OUTPUT  2
 #define HID_REPORT_TYPE_FEATURE 3
 
-#define HID_INTERFACE		(CDC_ACM_INTERFACE + CDC_INTERFACE_COUNT)		// HID Interface
-#define HID_FIRST_ENDPOINT	(CDC_FIRST_ENDPOINT + CDC_ENPOINT_COUNT)
-#define HID_ENDPOINT_INT	(HID_FIRST_ENDPOINT)
-#define HID_ENDPOINT_OUT	(HID_FIRST_ENDPOINT+1)   
-
-#define HID_TX HID_ENDPOINT_INT
-#define HID_RX HID_ENDPOINT_OUT     //++ EP  HID_RX for ease of use with USB_Available & USB_Rec
-
 typedef struct
 {
   uint8_t len;      // 9


### PR DESCRIPTION
Adopt coding style from https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/HID/src/HID.cpp that uses "pluggedEndpoint" from the PluggableUSBModule base-class as endpoint number instead of a hardcoded preprocessor define. This allows removal of several defines in the header that are now unused.

Benefits:
* Closer alignment to the upstream Arduino sources.
* Fewer hardcoded values, which will simplify future scaling to support multiple batteries in a USB composite device.
