### PR TITLE
Change voltage, capacity & chemistry to more closely match an actual battery

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -10,7 +10,7 @@ int iIntTimer=0;
 
 
 // String constants 
-const char STRING_DEVICECHEMISTRY[] PROGMEM = "PbAc";
+const char STRING_DEVICECHEMISTRY[] PROGMEM = "LiP";
 const char STRING_OEMVENDOR[] PROGMEM = "MyCoolUPS";
 const char STRING_SERIAL[] PROGMEM = "UPS10"; 
 
@@ -23,8 +23,8 @@ byte bRechargable = 1;
 byte bCapacityMode = 0;  // unit: 0=mAh, 1=mWh, 2=%
 
 // Physical parameters
-const uint16_t iConfigVoltage = 1380; // centiVolt
-uint16_t iVoltage =1300; // centiVolt
+const uint16_t iConfigVoltage = 1509; // centiVolt
+uint16_t iVoltage =1499; // centiVolt
 uint16_t iRunTimeToEmpty = 0, iPrevRunTimeToEmpty = 0;
 uint16_t iAvgTimeToFull = 7200;
 uint16_t iAvgTimeToEmpty = 7200;
@@ -36,12 +36,12 @@ byte iAudibleAlarmCtrl = 2; // 1 - Disabled, 2 - Enabled, 3 - Muted
 
 
 // Parameters for ACPI compliancy
-const uint32_t iDesignCapacity = 100*360/iVoltage; // AmpSec=mWh*360/centiVolt (1 mAh = 3.6 As)
+const uint32_t iDesignCapacity = 58003*360/iVoltage; // AmpSec=mWh*360/centiVolt (1 mAh = 3.6 As)
 byte iWarnCapacityLimit = 10; // warning at 10% 
 byte iRemnCapacityLimit = 5; // low at 5% 
 const byte bCapacityGranularity1 = 1;
 const byte bCapacityGranularity2 = 1;
-uint32_t iFullChargeCapacity = 100*360/iVoltage; // AmpSec=mWh*360/centiVolt (1 mAh = 3.6 As)
+uint32_t iFullChargeCapacity = 40690*360/iVoltage; // AmpSec=mWh*360/centiVolt (1 mAh = 3.6 As)
 
 uint32_t iRemaining =0, iPrevRemaining=0;
 bool bCharging = false;


### PR DESCRIPTION
Using a Dell Latitude 5330 battery pack as template.

Update & document units to fix capacity overflow problems.