### PR TITLE
Remove broken sendDate function

### DIFF
--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -236,11 +236,6 @@ HIDPowerDevice_::HIDPowerDevice_(void) {
     SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
 }
 
-int HIDPowerDevice_::sendDate(uint8_t id, uint16_t year, uint8_t month, uint8_t day) {
-    uint16_t bval = (year - 1980)*512 + month * 32 + day;
-    return SendReport(id, &bval, sizeof (bval));
-}
-
 int HIDPowerDevice_::setStringFeature(uint8_t id, const uint8_t* index, const char* data) {
     
     int res = SetFeature(id, index, 1);

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -111,8 +111,6 @@ private:
 public:
   HIDPowerDevice_(void);
   
-  int sendDate(uint8_t id, uint16_t year, uint8_t month, uint8_t day);
-  
   int setStringFeature(uint8_t id, const uint8_t* index, const char* data);
 };
 


### PR DESCRIPTION
The method currently uses a local `bval` variable as argument when calling `SendReport(...)`. This is problematic, since the `SendReport` method doesn't use `bval` immediately. It instead captures a pointer to `bval` which is accessed when the report is sent at a later point. This leads to a use-after-free situation when the pointer captured by `SendReport` no longer point to `bval`, but some other unknown data.