### PR TITLE
Update Linux ProductID rule to 8037 (Arduino micro)

### DIFF
--- a/linux/98-upower-hid.rules
+++ b/linux/98-upower-hid.rules
@@ -1,4 +1,4 @@
 # TODO: Adjust idProduct to match ProductID for the Arduino board used
 ATTRS{idVendor}=="2341", ENV{UPOWER_VENDOR}="Arduino"
-ATTRS{idVendor}=="2341", ATTRS{idProduct}=="8036", ENV{UPOWER_BATTERY_TYPE}="ups"
+ATTRS{idVendor}=="2341", ATTRS{idProduct}=="8037", ENV{UPOWER_BATTERY_TYPE}="ups"
 


### PR DESCRIPTION
Done to make the rule work out-of-the-box without any editing on Linux.