### PR TITLE
Propagate manufacturer name

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -90,6 +90,7 @@ void setup() {
 
     PowerDevice[i].setStringFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
     PowerDevice[i].setStringFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
+    PowerDevice[i].SetFeature(0xFF00 | PowerDevice[i].bManufacturer, STRING_OEMVENDOR, strlen_P(STRING_OEMVENDOR));
 
     PowerDevice[i].SetFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
 

--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -13,7 +13,7 @@ int iIntTimer=0;
 const char STRING_DEVICECHEMISTRY[] PROGMEM = "LiP";
 const byte bDeviceChemistry = IDEVICECHEMISTRY;
 
-const char STRING_OEMVENDOR[] PROGMEM = "MyCoolUPS";
+const char STRING_OEMVENDOR[] PROGMEM = "BatteryVendor";
 const byte bOEMVendor = IOEMVENDOR;
 
 const char STRING_SERIAL[] PROGMEM = "UPS10";

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -101,9 +101,7 @@ static_assert(sizeof(PresentStatus) == sizeof(uint16_t));
 
 
 class HIDPowerDevice_ : public HID_ {
-    
-private:
-    
+public:
     const byte bProduct = IPRODUCT;
     const byte bManufacturer = IMANUFACTURER;
     const byte bSerial = ISERIAL;  


### PR DESCRIPTION
This makes the manufacturer name show up in the "BatteryManufactureName" field on Windows.
