### PR TITLE
Propagate serial number

### DIFF
--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -65,8 +65,7 @@ void setup() {
     PowerDevice[i].setOutput(Serial);
 #endif
 
-    // Serial No is set in a special way as it forms Arduino port name
-    PowerDevice[i].setSerial(STRING_SERIAL); 
+    PowerDevice[i].SetFeature(0xFF00 | PowerDevice[i].bSerial, STRING_SERIAL, strlen_P(STRING_SERIAL));
   }
 
   pinMode(CHGDCHPIN, INPUT_PULLUP); // ground this pin to simulate power failure. 

--- a/examples/UPS/UPS.ino
+++ b/examples/UPS/UPS.ino
@@ -16,7 +16,7 @@ const byte bDeviceChemistry = IDEVICECHEMISTRY;
 const char STRING_OEMVENDOR[] PROGMEM = "BatteryVendor";
 const byte bOEMVendor = IOEMVENDOR;
 
-const char STRING_SERIAL[] PROGMEM = "UPS10";
+const char STRING_SERIAL[] PROGMEM = "1234";
 
 PresentStatus iPresentStatus = {}, iPreviousStatus = {};
 

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -91,21 +91,13 @@ int HID_::getDescriptor(USBSetup& setup)
 
 uint8_t HID_::getShortName(char *name)
 {
-    if(serial) {
-        for(byte i=0; i<strlen_P(serial); i++) {
-            name[i] = pgm_read_byte_near(serial + i);
-        }
-        return strlen_P(serial);
-    }
-    else {
-        // default serial number
-        name[0] = 'H';
-        name[1] = 'I';
-        name[2] = 'D';
-        name[3] = 'A' + (descriptorSize & 0x0F);
-        name[4] = 'A' + ((descriptorSize >> 4) & 0x0F);
-        return 5;
-    }
+    // default serial number
+    name[0] = 'H';
+    name[1] = 'I';
+    name[2] = 'D';
+    name[3] = 'A' + (descriptorSize & 0x0F);
+    name[4] = 'A' + ((descriptorSize >> 4) & 0x0F);
+    return 5;
 }
 
 void HID_::AppendDescriptor(HIDSubDescriptor *node)

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -114,10 +114,6 @@ public:
         dbg = &out;
     }
     
-    void setSerial(const char* s) {
-        serial = s;
-    }
-    
     HIDReport* GetFeature(uint16_t id);
     
 protected:
@@ -141,8 +137,6 @@ private:
     uint16_t reportCount;
     
     Serial_ *dbg = nullptr;
-    
-    const char *serial = nullptr; 
 };
 
 #define D_HIDREPORT(length) { 9, 0x21, 0x01, 0x01, 0, 1, 0x22, lowByte(length), highByte(length) }


### PR DESCRIPTION
This makes the manufacturer name show up in the "BatterySerialNumber" field on Windows.

I've been unable to figure out what the `getShortName` result is actually used for.