### PR TITLE
Remove unused HID_::setOutput method

### DIFF
--- a/battery/battery.ino
+++ b/battery/battery.ino
@@ -49,11 +49,6 @@ void setup() {
     // initialize batteries with 30% charge
     iRemaining[i] = 0.30f*iFullChargeCapacity;
 
-#ifdef CDC_ENABLED
-    // Used for debugging purposes. 
-    PowerDevice[i].setOutput(Serial);
-#endif
-
     PowerDevice[i].SetFeature(0xFF00 | PowerDevice[i].bSerial, STRING_SERIAL, strlen_P(STRING_SERIAL));
   }
 

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -110,10 +110,6 @@ public:
     
     void AppendDescriptor(HIDSubDescriptor* node);
     
-    void setOutput(Serial_& out) {
-        dbg = &out;
-    }
-    
     HIDReport* GetFeature(uint16_t id);
     
 protected:
@@ -135,8 +131,6 @@ private:
     // Buffer pointer to hold the feature data
     HIDReport* rootReport = nullptr;
     uint16_t reportCount;
-    
-    Serial_ *dbg = nullptr;
 };
 
 #define D_HIDREPORT(length) { 9, 0x21, 0x01, 0x01, 0, 1, 0x22, lowByte(length), highByte(length) }


### PR DESCRIPTION
This method is not present in the upstream https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/HID/src/HID.h class.