### PR TITLE
Rename setStringFeature method to SetStringIdxFeature

### DIFF
--- a/battery/battery.ino
+++ b/battery/battery.ino
@@ -69,8 +69,8 @@ void setup() {
     PowerDevice[i].SetFeature(HID_PD_CONFIGVOLTAGE, &iConfigVoltage, sizeof(iConfigVoltage));
     PowerDevice[i].SetFeature(HID_PD_VOLTAGE, &iVoltage, sizeof(iVoltage));
 
-    PowerDevice[i].setStringFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
-    PowerDevice[i].setStringFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
+    PowerDevice[i].SetStringIdxFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
+    PowerDevice[i].SetStringIdxFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
     PowerDevice[i].SetFeature(0xFF00 | PowerDevice[i].bManufacturer, STRING_OEMVENDOR, strlen_P(STRING_OEMVENDOR));
 
     PowerDevice[i].SetFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -236,14 +236,14 @@ HIDPowerDevice_::HIDPowerDevice_(void) {
     SetFeature(HID_PD_MANUFACTURER, &bManufacturer, sizeof(bManufacturer));
 }
 
-int HIDPowerDevice_::setStringFeature(uint8_t id, const uint8_t* index, const char* data) {
-    
+int HIDPowerDevice_::SetStringIdxFeature(uint8_t id, const uint8_t* index, const char* data) {
+    // set string index for report
     int res = SetFeature(id, index, 1);
+    if(res <= 0)
+        return res;
     
-    if(res == 0) return 0;
-    
-    res += SetFeature(0xFF00 | *index , data, strlen_P(data));
-    
+    // set string at given index
+    res = SetFeature(0xFF00 | *index , data, strlen_P(data));
     return res;
 }
 

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -109,7 +109,7 @@ public:
 public:
   HIDPowerDevice_(void);
   
-  int setStringFeature(uint8_t id, const uint8_t* index, const char* data);
+  int SetStringIdxFeature(uint8_t id, const uint8_t* index, const char* data);
 };
 
 // max number of batteries supported by the HW


### PR DESCRIPTION
Done to clarify that the method does two things, namely sets the string index for the report and sets the string at the given index.