### PR TITLE
Introduce new HID_::SetString method

### DIFF
--- a/battery/battery.ino
+++ b/battery/battery.ino
@@ -49,7 +49,7 @@ void setup() {
     // initialize batteries with 30% charge
     iRemaining[i] = 0.30f*iFullChargeCapacity;
 
-    PowerDevice[i].SetFeature(0xFF00 | PowerDevice[i].bSerial, STRING_SERIAL, strlen_P(STRING_SERIAL));
+    PowerDevice[i].SetString(PowerDevice[i].bSerial, STRING_SERIAL);
   }
 
   pinMode(LED_BUILTIN, OUTPUT);  // output flushing 1 sec indicating that the arduino cycle is running.
@@ -71,7 +71,7 @@ void setup() {
 
     PowerDevice[i].SetStringIdxFeature(HID_PD_IDEVICECHEMISTRY, &bDeviceChemistry, STRING_DEVICECHEMISTRY);
     PowerDevice[i].SetStringIdxFeature(HID_PD_IOEMINFORMATION, &bOEMVendor, STRING_OEMVENDOR);
-    PowerDevice[i].SetFeature(0xFF00 | PowerDevice[i].bManufacturer, STRING_OEMVENDOR, strlen_P(STRING_OEMVENDOR));
+    PowerDevice[i].SetString(PowerDevice[i].bManufacturer, STRING_OEMVENDOR);
 
     PowerDevice[i].SetFeature(HID_PD_AUDIBLEALARMCTRL, &iAudibleAlarmCtrl, sizeof(iAudibleAlarmCtrl));
 

--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -137,6 +137,11 @@ int HID_::SetFeature(uint16_t id, const void* data, int len)
     return reportCount;
 }
 
+int HID_::SetString(const uint8_t index, const char* data)
+{
+    return SetFeature(0xFF00 | index, data, strlen_P(data));
+}
+
 int HID_::SendReport(uint8_t id, const void* data, int len)
 {
     auto ret = USB_Send(pluggedEndpoint, &id, 1);

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -107,6 +107,7 @@ public:
     HID_(void);
     int SendReport(uint8_t id, const void* data, int len);
     int SetFeature(uint16_t id, const void* data, int len);
+    int SetString(const uint8_t index, const char* data);
     
     void AppendDescriptor(HIDSubDescriptor* node);
     

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -243,7 +243,7 @@ int HIDPowerDevice_::SetStringIdxFeature(uint8_t id, const uint8_t* index, const
         return res;
     
     // set string at given index
-    res = SetFeature(0xFF00 | *index , data, strlen_P(data));
+    res = SetString(*index , data);
     return res;
 }
 


### PR DESCRIPTION
Done to avoid leaking out the HID_ class 0xFF arithmetic pattern to the HIDPowerDevice_ class and client code.