### PR TITLE
Change HID_::SetFeature "id" argument from 16 to 8bits

### DIFF
--- a/src/HID/HID.cpp
+++ b/src/HID/HID.cpp
@@ -114,7 +114,17 @@ void HID_::AppendDescriptor(HIDSubDescriptor *node)
     descriptorSize += node->length;
 }
 
-int HID_::SetFeature(uint16_t id, const void* data, int len)
+int HID_::SetFeature(uint8_t id, const void* data, int len)
+{
+    return SetFeatureInternal(0x0000 | id, data, len); // expand id to 16bits
+}
+
+int HID_::SetString(const uint8_t index, const char* data)
+{
+    return SetFeatureInternal(0xFF00 | index, data, strlen_P(data)); // expand index to 16bits
+}
+
+int HID_::SetFeatureInternal(uint16_t id, const void* data, int len)
 {
     if(!rootReport) {
         rootReport = new HIDReport(id, data, len);
@@ -135,11 +145,6 @@ int HID_::SetFeature(uint16_t id, const void* data, int len)
 
     reportCount++;
     return reportCount;
-}
-
-int HID_::SetString(const uint8_t index, const char* data)
-{
-    return SetFeature(0xFF00 | index, data, strlen_P(data));
 }
 
 int HID_::SendReport(uint8_t id, const void* data, int len)

--- a/src/HID/HID.h
+++ b/src/HID/HID.h
@@ -106,7 +106,7 @@ class HID_ : public PluggableUSBModule
 public:
     HID_(void);
     int SendReport(uint8_t id, const void* data, int len);
-    int SetFeature(uint16_t id, const void* data, int len);
+    int SetFeature(uint8_t id, const void* data, int len);
     int SetString(const uint8_t index, const char* data);
     
     void AppendDescriptor(HIDSubDescriptor* node);
@@ -121,6 +121,8 @@ protected:
     uint8_t getShortName(char* name) override;
     
 private:
+    int SetFeatureInternal(uint16_t id, const void* data, int len);
+
     uint8_t epType[1];
 
     HIDSubDescriptor* rootNode = nullptr;


### PR DESCRIPTION
Move the underlying impl. that uses a 16bit "id" to an private internal method. Done to tighten the public API to make client usage more intuitive.