### PR TITLE
Move battery creation to the sample file

### DIFF
--- a/battery/battery.ino
+++ b/battery/battery.ino
@@ -36,8 +36,10 @@ const byte bCapacityGranularity1 = 1;
 const byte bCapacityGranularity2 = 1;
 uint16_t iFullChargeCapacity = 40690*360/iVoltage; // AmpSec=mWh*360/centiVolt (1 mAh = 3.6 As)
 
-uint16_t iRemaining[BATTERY_COUNT] = {}; // remaining charge
+uint16_t iRemaining[MAX_BATTERIES] = {}; // remaining charge
 uint16_t iPrevRemaining=0;
+
+HIDPowerDevice_ PowerDevice[MAX_BATTERIES];
 
 
 void setup() {
@@ -45,7 +47,7 @@ void setup() {
   Serial.begin(57600);
 #endif
 
-  for (int i = 0; i < BATTERY_COUNT; i++) {
+  for (int i = 0; i < MAX_BATTERIES; i++) {
     // initialize batteries with 30% charge
     iRemaining[i] = 0.30f*iFullChargeCapacity;
 
@@ -54,7 +56,7 @@ void setup() {
 
   pinMode(LED_BUILTIN, OUTPUT);  // output flushing 1 sec indicating that the arduino cycle is running.
 
-  for (int i = 0; i < BATTERY_COUNT; i++) {
+  for (int i = 0; i < MAX_BATTERIES; i++) {
     PowerDevice[i].SetFeature(HID_PD_PRESENTSTATUS, &iPresentStatus, sizeof(iPresentStatus));
 
     PowerDevice[i].SetFeature(HID_PD_RUNTIMETOEMPTY, &iRunTimeToEmpty, sizeof(iRunTimeToEmpty));
@@ -91,7 +93,7 @@ void setup() {
 
 void loop() {
   // propagate charge level from first to last battery
-  for (int i = BATTERY_COUNT-1; i > 0; i--)
+  for (int i = MAX_BATTERIES-1; i > 0; i--)
     iRemaining[i] = iRemaining[i-1];
 
 #ifdef ENABLE_POTENTIOMETER
@@ -158,7 +160,7 @@ void loop() {
 
   //************ Bulk send or interrupt ***********************
   int res = 0;
-  for (int i = 0; i < BATTERY_COUNT; i++) {
+  for (int i = 0; i < MAX_BATTERIES; i++) {
     if (res >= 0)
       res = PowerDevice[i].SendReport(HID_PD_REMAININGCAPACITY, &iRemaining[i], sizeof(iRemaining[i]));
 

--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -247,7 +247,5 @@ int HIDPowerDevice_::SetStringIdxFeature(uint8_t id, const uint8_t* index, const
     return res;
 }
 
-HIDPowerDevice_ PowerDevice[BATTERY_COUNT];
-
 #endif
 

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -113,9 +113,7 @@ public:
 };
 
 // max number of batteries supported by the HW
-#define BATTERY_COUNT (USB_ENDPOINTS - CDC_FIRST_ENDPOINT - CDC_ENPOINT_COUNT) // 3 by default; 6 if defining CDC_DISABLED
-
-extern HIDPowerDevice_ PowerDevice[BATTERY_COUNT];
+#define MAX_BATTERIES (USB_ENDPOINTS - CDC_FIRST_ENDPOINT - CDC_ENPOINT_COUNT) // 3 by default; 6 if defining CDC_DISABLED
 
 #endif
 #endif


### PR DESCRIPTION
Done to allow client-side control of the number of batteries created.