### PR TITLE
Reduce CapacityGranularity1&2 to a single report

### DIFF
--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -72,7 +72,7 @@ static const uint8_t _hidReportDescriptor[] PROGMEM = {
     0x85, HID_PD_CPCTYGRANULARITY1, //     REPORT_ID (16)
     0x09, 0x8D, //     USAGE (CapacityGranularity1)
     0x75, 0x10, //     REPORT_SIZE (16)
-    0x95, 0x04, //     REPORT_COUNT (4)
+    0x95, 0x01, //     REPORT_COUNT (1)
     0x67, 0x01, 0x10, 0x10, 0x00, //     UNIT (AmpSec)
     0x55, 0x00, //     UNIT_EXPONENT (0)
     0xB1, 0x22, //     FEATURE (Data, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Nonvolatile, Bitfield)


### PR DESCRIPTION
Done to reduce the `FeatureReportByteLength` from 9 to 3 bytes. The Windows integration seem unaffected.