### PR TITLE
Stop hardcoding string indices in the HID report descriptor

### DIFF
--- a/src/HIDPowerDevice.cpp
+++ b/src/HIDPowerDevice.cpp
@@ -34,23 +34,19 @@ static const uint8_t s_hidReportDescriptor[] PROGMEM = {
     0x26, 0xFF, 0x00, //     LOGICAL_MAXIMUM (255)
     0x85, HID_PD_IPRODUCT, //     REPORT_ID (1)
     0x09, 0xFE, //     USAGE (iProduct)
-    0x79, IPRODUCT, //     STRING INDEX (2)
     0xB1, 0x23, //     FEATURE (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Nonvolatile, Bitfield)
 
     0x85, HID_PD_SERIAL, //     REPORT_ID (2)
     0x09, 0xFF, //     USAGE (iSerialNumber)
-    0x79, ISERIAL, //  STRING INDEX (3)
     0xB1, 0x23, //     FEATURE (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Nonvolatile, Bitfield)
 
     0x85, HID_PD_MANUFACTURER, //     REPORT_ID (3)
     0x09, 0xFD, //     USAGE (iManufacturer)
-    0x79, IMANUFACTURER, //     STRING INDEX (1)
     0xB1, 0x23, //     FEATURE (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Nonvolatile, Bitfield)
 
     0x05, 0x85, //     USAGE_PAGE (Battery System) ====================
     0x85, HID_PD_IDEVICECHEMISTRY, //     REPORT_ID (4)
     0x09, 0x89, //     USAGE (iDeviceChemistry)
-    0x79, IDEVICECHEMISTRY, //     STRING INDEX (4)
     0xB1, 0x23, //     FEATURE (Constant, Variable, Absolute, No Wrap, Linear, No Preferred, No Null Position, Nonvolatile, Bitfield)
 
     0x85, HID_PD_CAPACITYMODE, //     REPORT_ID (22)


### PR DESCRIPTION
Done, to reduce hardcoding and make it easier to support device-specific string reports when exposing multiple HID devices in a USB composite device.

The string indices in the HID report descriptor doesn't seem to be used for anything, since the actual string indices are retrieved through a HID `FEATURE` report request that will return the actual string index. The change furthermore doesn't seem to break anything - at least when testing in Windows. The Windows `HidBatt` driver will still retrieve all the strings in question without any noticeable problems.

## BatteryQuery output
[BatteryQuery](https://github.com/forderud/BatterySimulator/releases) output with this PR:
```
Opening HID\VID_2341&PID_8037&MI_04\7&5A3CEF3&0&0000:

Misc. IOCTL_BATTERY_QUERY_INFORMATION parameters:
  BatteryDeviceName:      Arduino Micro
  BatteryEstimatedTime:   1440 s
  BatteryGranularityInformation 0: Resolution=0 mWh for Capacity<=5800 mWh
  BatteryGranularityInformation 1: Resolution=0 mWh for Capacity<=58002 mWh
  BatteryManufactureDate: 2024-10-12
  BatteryManufactureName: BatteryVendor
  BatterySerialNumber:    1234
  BatteryTemperature:     26.9 Celsius
  BatteryUniqueID:        1234BatteryVendorArduino Micro

BATTERY_INFORMATION parameters:
  Capabilities=| IS_SHORT_TERM | SYSTEM_BATTERY
  Technology=Rechargeable
  Chemistry=LiP
  DesignedCapacity=58002 mWh
  FullChargedCapacity=40689 mWh
  DefaultAlert1=2898 mWh (critical battery alarm)
  DefaultAlert2=5800 mWh (low battery alarm)
  CriticalBias=0 mWh (reserve capacity)
  CycleCount=42

BATTERY_STATUS parameters:
  PowerState=| DISCHARGING
  Capacity=12204 mWh
  Voltage=14990 mV
  (Dis)Charge Rate=<unknown>


Opening HID\VID_2341&PID_8037&MI_02\7&1ADE607E&0&0000:

Misc. IOCTL_BATTERY_QUERY_INFORMATION parameters:
  BatteryDeviceName:      Arduino Micro
  BatteryEstimatedTime:   1440 s
  BatteryGranularityInformation 0: Resolution=0 mWh for Capacity<=5800 mWh
  BatteryGranularityInformation 1: Resolution=0 mWh for Capacity<=58002 mWh
  BatteryManufactureDate: 2024-10-12
  BatteryManufactureName: BatteryVendor
  BatterySerialNumber:    1234
  BatteryTemperature:     26.9 Celsius
  BatteryUniqueID:        1234BatteryVendorArduino Micro

BATTERY_INFORMATION parameters:
  Capabilities=| IS_SHORT_TERM | SYSTEM_BATTERY
  Technology=Rechargeable
  Chemistry=LiP
  DesignedCapacity=58002 mWh
  FullChargedCapacity=40689 mWh
  DefaultAlert1=2898 mWh (critical battery alarm)
  DefaultAlert2=5800 mWh (low battery alarm)
  CriticalBias=0 mWh (reserve capacity)
  CycleCount=42

BATTERY_STATUS parameters:
  PowerState=| DISCHARGING
  Capacity=11388 mWh
  Voltage=14990 mV
  (Dis)Charge Rate=<unknown>

Opening HID\VID_2341&PID_8037&MI_03\7&2E0E7CBC&0&0000:

Misc. IOCTL_BATTERY_QUERY_INFORMATION parameters:
  BatteryDeviceName:      Arduino Micro
  BatteryEstimatedTime:   1440 s
  BatteryGranularityInformation 0: Resolution=0 mWh for Capacity<=5800 mWh
  BatteryGranularityInformation 1: Resolution=0 mWh for Capacity<=58002 mWh
  BatteryManufactureDate: 2024-10-12
  BatteryManufactureName: BatteryVendor
  BatterySerialNumber:    1234
  BatteryTemperature:     26.9 Celsius
  BatteryUniqueID:        1234BatteryVendorArduino Micro

BATTERY_INFORMATION parameters:
  Capabilities=| IS_SHORT_TERM | SYSTEM_BATTERY
  Technology=Rechargeable
  Chemistry=LiP
  DesignedCapacity=58002 mWh
  FullChargedCapacity=40689 mWh
  DefaultAlert1=2898 mWh (critical battery alarm)
  DefaultAlert2=5800 mWh (low battery alarm)
  CriticalBias=0 mWh (reserve capacity)
  CycleCount=42

BATTERY_STATUS parameters:
  PowerState=| DISCHARGING
  Capacity=12204 mWh
  Voltage=14990 mV
  (Dis)Charge Rate=<unknown>
```

All text strings are still correctly reported as shown above.