### PR TITLE
Stop intercepting Temperature values

### DIFF
--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -12,17 +12,6 @@ static void UpdateBatteryInformation(BATTERY_INFORMATION& bi, SharedState& state
     DebugPrint(DPFLTR_INFO_LEVEL, "EvtIoDeviceControlBattFilterCompletion: UpdateBatteryInformation CycleCount before=%u, after=%u\n", CycleCountBefore, bi.CycleCount); CycleCountBefore;
 }
 
-static void UpdateBatteryTemperature(ULONG& temp, SharedState& state) {
-    auto TempBefore = temp;
-
-    WdfSpinLockAcquire(state.Lock);
-    temp = state.Temperature;
-    WdfSpinLockRelease(state.Lock);
-
-    DebugPrint(DPFLTR_INFO_LEVEL, "EvtIoDeviceControlBattFilterCompletion: UpdateBatteryTemperature before=%u, after=%u\n", TempBefore, temp); TempBefore;
-}
-
-
 void EvtIoDeviceControlBattFilterCompletion (_In_  WDFREQUEST Request, _In_  WDFIOTARGET Target, _In_  WDF_REQUEST_COMPLETION_PARAMS* Params, _In_  WDFCONTEXT Context) {
     UNREFERENCED_PARAMETER(Target);
     UNREFERENCED_PARAMETER(Context);
@@ -69,9 +58,6 @@ void EvtIoDeviceControlBattFilterCompletion (_In_  WDFREQUEST Request, _In_  WDF
     if ((Ioctl->InformationLevel == BatteryInformation) && (Ioctl->OutputBufferLength == sizeof(BATTERY_INFORMATION))) {
         auto* bi = (BATTERY_INFORMATION*)Ioctl->OutputBuffer;
         UpdateBatteryInformation(*bi, *context->Interface.State);
-    } else if ((Ioctl->InformationLevel == BatteryTemperature) && (Ioctl->OutputBufferLength == sizeof(ULONG))) {
-        auto* temp = (ULONG*)Ioctl->OutputBuffer;
-        UpdateBatteryTemperature(*temp, *context->Interface.State);
     }
 
     WdfRequestComplete(Request, status);

--- a/HidBattExt/README.md
+++ b/HidBattExt/README.md
@@ -1,5 +1,5 @@
 # Windows HidBatt extension filter driver
-`HidBattExt` driver that extends the in-built `HidBatt` driver in Windows to also parse and report `CycleCount` and `Temperature` battery parameters.
+`HidBattExt` driver that extends the in-built `HidBatt` driver in Windows to also parse and report the `CycleCount` battery parameter.
 
 The HidBatt drivers inability to report these parameters have already been reported to Microsoft in https://aka.ms/AAu4w9g and https://aka.ms/AAu4w8p . The driver will no longer be needed if or when Microsoft improves their `HidBatt` driver.
 
@@ -7,7 +7,7 @@ The HidBatt drivers inability to report these parameters have already been repor
 The filter driver places itself both _above_ and _below_ HidBatt:  
 ![image](https://github.com/user-attachments/assets/33d408cf-95e1-4501-9363-cfe81e34bf4c)
 
-The driver instance _below_ HidBatt first filters the HID Power Device communication with the battery to pick up the missing `CycleCount` and `Temperature` parameters from HID `FEATURE` and `INPUT` reports. The driver instance _above_ HidBatt afterwards filters [`IOCTL_BATTERY_QUERY_INFORMATION`](https://learn.microsoft.com/en-us/windows/win32/power/ioctl-battery-query-information) communication to include these parameters in the HidBatt responses.
+The driver instance _below_ HidBatt first filters the HID Power Device communication with the battery to pick up the missing `CycleCount` parameter from HID `FEATURE` and `INPUT` reports. The driver instance _above_ HidBatt afterwards filters [`IOCTL_BATTERY_QUERY_INFORMATION`](https://learn.microsoft.com/en-us/windows/win32/power/ioctl-battery-query-information) communication to include these parameters in the HidBatt responses.
 
 ### Open issues
 **WARNING**: The driver does work, but please be warned that it's **work in progress** and not yet ready for production usage. See  [_windows_ issues](https://github.com/forderud/HidBattery/issues?q=is%3Aissue%20state%3Aopen%20label%3Awindows) for a list of known issues and improvement plans.

--- a/HidBattExt/device.h
+++ b/HidBattExt/device.h
@@ -11,7 +11,6 @@ public:
     WDFSPINLOCK Lock = 0;  // to protext member access
 
     ULONG CycleCount;  // BATTERY_INFORMATION::CycleCount value
-    ULONG Temperature; // IOCTL_BATTERY_QUERY_INFORMATION BatteryTemperature value
 
     void Initialize(WDFDEVICE device) {
         WDF_OBJECT_ATTRIBUTES attribs{};
@@ -92,7 +91,6 @@ WDF_DECLARE_CONTEXT_TYPE(REQUEST_CONTEXT)
 struct DEVICE_CONTEXT {
     FilterMode     Mode;      // upper or lower driver instance
     UNICODE_STRING PdoName;
-    UCHAR          TemperatureReportID;
     UCHAR          CycleCountReportID;
     SharedState    LowState;  // lower filter instance state (not accessible from upper filter)
     HidBattExtIf   Interface; // for communication between driver instances

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ Limtation: Linux seem to assume charge values in `%`, regardless of the actual u
 
 
 # Windows HidBatt filter driver
-This repo also contains a [`HidBattExt`](HidBattExt/) filter driver that extends the in-built `HidBatt` driver in Windows to also parse and report `CycleCount` and `Temperature` battery parameters.
+This repo also contains a [`HidBattExt`](HidBattExt/) filter driver that extends the in-built `HidBatt` driver in Windows to also parse and report the `CycleCount` battery parameter.


### PR DESCRIPTION
It seems like the HidBatt driver is after all able to parse the battery Temperature parameter. The communication appear to go through some undocumented IOCTL codes though, which confuses me.