### PR TITLE
Defer Lower driver queue creation until HidState have been initialized

### DIFF
--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -22,13 +22,19 @@ VOID HidPdFeatureRequestTimer(_In_ WDFTIMER  Timer) {
     {
         // create queue for filtering HID Power Device requests now that HidState have been initialized
         WDF_IO_QUEUE_CONFIG queueConfig = {};
-        WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
+        WDF_IO_QUEUE_CONFIG_INIT(&queueConfig, WdfIoQueueDispatchParallel);
         queueConfig.EvtIoRead = EvtIoReadHidFilter; // filter read requests
 
         WDFQUEUE queue = 0; // auto-deleted when "Device" is deleted
         status = WdfIoQueueCreate(Device, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, &queue);
         if (!NT_SUCCESS(status)) {
             DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfIoQueueCreate failed 0x%x"), status);
+            return;
+        }
+
+        status = WdfDeviceConfigureRequestDispatching(Device, queue, WdfRequestTypeRead);
+        if (!NT_SUCCESS(status)) {
+            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfDeviceConfigureRequestDispatching(queue, RequestTypeRead) failed 0x%x"), status);
             return;
         }
     }


### PR DESCRIPTION
WinDBG error:
```
Leaving HidPdFeatureRequest
HidBattExt: WdfIoQueueCreate failed 0xc0000184 (STATUS_INVALID_DEVICE_STATE)
```

Next error after making queue non-default:
```
HidBattExt: WdfIoTargetOpen failed 0xc000000e (STATUS_NO_SUCH_DEVICE)
```

Next error after creating dummy default queue:
```
HidBattExt: WdfIoQueueCreate failed 0xc020020b (STATUS_WDF_NO_CALLBACK)
```

## Doc
* https://learn.microsoft.com/en-us/windows-hardware/drivers/wdf/creating-i-o-queues
