### PR TITLE
Set /brepro option for deterministic builds

### DIFF
--- a/HidBattExt/HidBattExt.vcxproj
+++ b/HidBattExt/HidBattExt.vcxproj
@@ -82,6 +82,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -94,6 +95,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -106,6 +108,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -118,6 +121,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>


### PR DESCRIPTION
Follow-up to 75430f495858b58019675263d546bfb6992a1715.

This undocumented linker flag will set all timestamps in the Portable Executable file to -1 as documented on https://blog.conan.io/2019/09/02/Deterministic-builds-with-C-C++.html . This will improve traceability between compiled driver binaries and the source code used to generate them.

Please note that the cryptographic signature may still differ between builds if using a time server or different signatures. This is expected and can be worked around by removing the signatures with `signtool.exe remove /s HidBattExt.sys` before comparing.

I've verified that **both debug- and release-builds of HidBattExt.sys are now binary identical every time when building with VS2022** after removing the signatures.
