### PR TITLE
WIP: Convert HidBattExt to a function driver

### DIFF
--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -97,7 +97,7 @@ Arguments:
         DevExt->State.ManufactureDate.Month = 0;
         DevExt->State.ManufactureDate.Year = 0;
 
-        DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY;
+        DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY | BATTERY_IS_SHORT_TERM;
         DevExt->State.BatteryInfo.Technology = 1; // rechargeable
 
         for (size_t i = 0; i < 4; i++)

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -109,7 +109,7 @@ Arguments:
         DevExt->State.BatteryInfo.DefaultAlert1 = 0;
         DevExt->State.BatteryInfo.DefaultAlert2 = 0;
         DevExt->State.BatteryInfo.CriticalBias = 0;
-        DevExt->State.BatteryInfo.CycleCount = 100;
+        DevExt->State.BatteryInfo.CycleCount = 0;
 
         DevExt->State.BatteryStatus.PowerState = BATTERY_POWER_ON_LINE;
         DevExt->State.BatteryStatus.Capacity = 90;
@@ -124,7 +124,7 @@ Arguments:
 
         DevExt->State.EstimatedTime = BATTERY_UNKNOWN_TIME; // battery run time, in seconds
 
-        DevExt->State.Temperature = 2981; // 25 degree Celsius [10ths of a degree Kelvin]
+        DevExt->State.Temperature = 0; // [10ths of a degree Kelvin]
 
         RtlStringCchCopyW(DevExt->State.DeviceName, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery");
 

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -114,7 +114,7 @@ Arguments:
         DevExt->State.BatteryStatus.PowerState = BATTERY_POWER_ON_LINE;
         DevExt->State.BatteryStatus.Capacity = 90;
         DevExt->State.BatteryStatus.Voltage = BATTERY_UNKNOWN_VOLTAGE;
-        DevExt->State.BatteryStatus.Rate = 0;
+        DevExt->State.BatteryStatus.Rate = BATTERY_UNKNOWN_RATE;
 
         //DevExt->State.GranularityCount = 0;
         //for (unsigned int i = 0; i < DevExt->State.GranularityCount; ++i) {

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -2,7 +2,7 @@
 #include "device.hpp"
 #include <Poclass.h> // for IOCTL_BATTERY_QUERY_INFORMATION
 
-
+#if 0
 static void UpdateBatteryInformation(BATTERY_INFORMATION& bi, BatteryState& state) {
     auto CycleCountBefore = bi.CycleCount;
 
@@ -122,3 +122,4 @@ VOID EvtIoDeviceControlBattFilter(
         WdfRequestComplete(Request, status);
     }
 }
+#endif

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -104,15 +104,15 @@ Arguments:
         DevExt->State.BatteryInfo.Chemistry[1] = 'a';
         DevExt->State.BatteryInfo.Chemistry[2] = 'k';
         DevExt->State.BatteryInfo.Chemistry[3] = 'e';
-        DevExt->State.BatteryInfo.DesignedCapacity = 110;
-        DevExt->State.BatteryInfo.FullChargedCapacity = 100;
+        DevExt->State.BatteryInfo.DesignedCapacity = 0;
+        DevExt->State.BatteryInfo.FullChargedCapacity = 0;
         DevExt->State.BatteryInfo.DefaultAlert1 = 0;
         DevExt->State.BatteryInfo.DefaultAlert2 = 0;
         DevExt->State.BatteryInfo.CriticalBias = 0;
         DevExt->State.BatteryInfo.CycleCount = 0;
 
         DevExt->State.BatteryStatus.PowerState = BATTERY_POWER_ON_LINE;
-        DevExt->State.BatteryStatus.Capacity = 90;
+        DevExt->State.BatteryStatus.Capacity = 0;
         DevExt->State.BatteryStatus.Voltage = BATTERY_UNKNOWN_VOLTAGE;
         DevExt->State.BatteryStatus.Rate = BATTERY_UNKNOWN_RATE;
 

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -580,3 +580,121 @@ Arguments:
 SetBatteryInformationEnd:
     return Status;
 }
+
+
+
+_Use_decl_annotations_
+NTSTATUS BattWdmIrpPreprocessDeviceControl(WDFDEVICE Device, IRP* Irp)
+/*++
+Routine Description:
+    This event is called when the framework receives IRP_MJ_DEVICE_CONTROL
+    requests from the system.
+
+    N.B. Battery stack requires the device IOCTLs be sent to it at
+         PASSIVE_LEVEL only, any IOCTL comming from user mode is therefore
+         fine, kernel components, such as filter drivers sitting on top of
+         the battery drivers should be careful to not voilate this
+         requirement.
+
+Arguments:
+    Device - Supplies a handle to a framework device object.
+
+    Irp - Supplies the IO request being processed.
+--*/
+{
+    DebugEnter();
+
+    ASSERTMSG("Must be called at IRQL = PASSIVE_LEVEL",
+        (KeGetCurrentIrql() == PASSIVE_LEVEL));
+
+    DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
+    NTSTATUS Status = STATUS_NOT_SUPPORTED;
+
+    // Suppress 28118:Irq Exceeds Caller, see Routine Description for
+    // explaination.
+#pragma warning(suppress: 28118)
+    WdfWaitLockAcquire(DevExt->ClassInitLock, NULL);
+
+    // N.B. An attempt to queue the IRP with the port driver should happen
+    //      before WDF assumes ownership of this IRP, i.e. before
+    //      WdfDeviceWdmDispatchPreprocessedIrp is called, this is so that the
+    //      Battery port driver, which is a WDM driver, may complete the IRP if
+    //      it does endup procesing it.
+    if (DevExt->ClassHandle != NULL) {
+        // Suppress 28118:Irq Exceeds Caller, see above N.B.
+#pragma warning(suppress: 28118)
+        Status = BatteryClassIoctl(DevExt->ClassHandle, Irp);
+    }
+
+    WdfWaitLockRelease(DevExt->ClassInitLock);
+    if (Status == STATUS_NOT_SUPPORTED) {
+        IoSkipCurrentIrpStackLocation(Irp);
+        Status = WdfDeviceWdmDispatchPreprocessedIrp(Device, Irp);
+    }
+
+    DebugExitStatus(Status);
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS BattWdmIrpPreprocessSystemControl(WDFDEVICE Device, IRP* Irp)
+/*++
+Routine Description:
+    This event is called when the framework receives IRP_MJ_SYSTEM_CONTROL
+    requests from the system.
+
+    N.B. Battery stack requires the device IOCTLs be sent to it at
+         PASSIVE_LEVEL only, any IOCTL comming from user mode is therefore
+         fine, kernel components, such as filter drivers sitting on top of
+         the battery drivers should be careful to not voilate this
+         requirement.
+
+Arguments:
+    Device - Supplies a handle to a framework device object.
+
+    Irp - Supplies the IO request being processed.
+--*/
+{
+    DebugEnter();
+    ASSERTMSG("Must be called at IRQL = PASSIVE_LEVEL", (KeGetCurrentIrql() == PASSIVE_LEVEL));
+
+    NTSTATUS Status = STATUS_NOT_IMPLEMENTED;
+    DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
+    SYSCTL_IRP_DISPOSITION Disposition = IrpForward;
+
+    // Acquire the class initialization lock and attempt to queue the IRP with
+    // the class driver.
+    //
+    // Suppress 28118:Irq Exceeds Caller, see Routine Description for
+    // explaination.
+#pragma warning(suppress: 28118)
+    WdfWaitLockAcquire(DevExt->ClassInitLock, NULL);
+    if (DevExt->ClassHandle != NULL) {
+        DEVICE_OBJECT* DeviceObject = WdfDeviceWdmGetDeviceObject(Device);
+        Status = BatteryClassSystemControl(DevExt->ClassHandle,
+            &DevExt->WmiLibContext,
+            DeviceObject,
+            Irp,
+            &Disposition);
+    }
+
+    WdfWaitLockRelease(DevExt->ClassInitLock);
+    switch (Disposition) {
+    case IrpProcessed:
+        break;
+
+    case IrpNotCompleted:
+        IoCompleteRequest(Irp, IO_NO_INCREMENT);
+        break;
+
+    case IrpForward:
+    case IrpNotWmi:
+    default:
+        IoSkipCurrentIrpStackLocation(Irp);
+        Status = WdfDeviceWdmDispatchPreprocessedIrp(Device, Irp);
+        break;
+    }
+
+    DebugExitStatus(Status);
+    return Status;
+}

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -125,13 +125,13 @@ Arguments:
 
         DevExt->State.Temperature = 0; // [10ths of a degree Kelvin]
 
-        RtlStringCchCopyW(DevExt->State.DeviceName, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery");
+        memset(DevExt->State.DeviceName, 0, sizeof(WCHAR)*MAX_BATTERY_STRING_SIZE);
 
-        RtlStringCchCopyW(DevExt->State.ManufacturerName, MAX_BATTERY_STRING_SIZE, L"OpenSource");
+        memset(DevExt->State.ManufacturerName, 0, sizeof(WCHAR)*MAX_BATTERY_STRING_SIZE);
 
-        RtlStringCchCopyW(DevExt->State.SerialNumber, MAX_BATTERY_STRING_SIZE, L"1234");
+        memset(DevExt->State.SerialNumber, 0, sizeof(WCHAR)*MAX_BATTERY_STRING_SIZE);
 
-        RtlStringCchCopyW(DevExt->State.UniqueId, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery007");
+        memset(DevExt->State.UniqueId, 0, sizeof(WCHAR)*MAX_BATTERY_STRING_SIZE);
 
         WdfSpinLockRelease(DevExt->State.Lock);
     }

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -601,7 +601,7 @@ Arguments:
     Irp - Supplies the IO request being processed.
 --*/
 {
-    DebugEnter();
+    //DebugEnter();
 
     ASSERTMSG("Must be called at IRQL = PASSIVE_LEVEL",
         (KeGetCurrentIrql() == PASSIVE_LEVEL));
@@ -631,7 +631,7 @@ Arguments:
         Status = WdfDeviceWdmDispatchPreprocessedIrp(Device, Irp);
     }
 
-    DebugExitStatus(Status);
+    //DebugExitStatus(Status);
     return Status;
 }
 

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -93,10 +93,9 @@ Arguments:
         WdfSpinLockAcquire(DevExt->State.Lock);
         UpdateTag(DevExt);
 
-        // manufactured on 8th September 2024
-        DevExt->State.ManufactureDate.Day = 8;
-        DevExt->State.ManufactureDate.Month = 9;
-        DevExt->State.ManufactureDate.Year = 2024;
+        DevExt->State.ManufactureDate.Day = 0;
+        DevExt->State.ManufactureDate.Month = 0;
+        DevExt->State.ManufactureDate.Year = 0;
 
         DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY;
         DevExt->State.BatteryInfo.Technology = 1;

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------- Prototypes
 
 _IRQL_requires_same_
-void UpdateTag (_Inout_ BATT_FDO_DATA* DevExt);
+void UpdateTag (_Inout_ DEVICE_CONTEXT* DevExt);
 
 BCLASS_QUERY_TAG_CALLBACK QueryTag;
 BCLASS_QUERY_INFORMATION_CALLBACK QueryInformation;
@@ -32,7 +32,7 @@ NTSTATUS SetBatteryInformation (_In_ WDFDEVICE Device, _In_ BATTERY_INFORMATION*
 
 NTSTATUS InitializeBattery(_In_ WDFDEVICE Device)
 {
-    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+    DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
 
     // Attach to the battery class driver
     BATTERY_MINIPORT_INFO_V1_1 BattInit = {};
@@ -71,7 +71,7 @@ Arguments:
 {
     DebugEnter();
 
-    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+    DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
 
     // Get this battery's state - use defaults.
     {
@@ -124,7 +124,7 @@ Arguments:
 }
 
 _Use_decl_annotations_
-void UpdateTag (BATT_FDO_DATA* DevExt)
+void UpdateTag (DEVICE_CONTEXT* DevExt)
 /*++
 Routine Description:
     This routine is called when static battery properties have changed to
@@ -152,7 +152,7 @@ Arguments:
 
     DebugEnter();
 
-    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     *BatteryTag = DevExt->BatteryTag;
     WdfWaitLockRelease(DevExt->StateLock);
@@ -211,7 +211,7 @@ Return Value:
 
     DebugEnter();
 
-    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
@@ -356,7 +356,7 @@ Return Value:
 
     DebugEnter();
 
-    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
@@ -403,7 +403,7 @@ Return Value:
 
     DebugEnter();
 
-    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
@@ -469,7 +469,7 @@ Arguments:
 
     DebugEnter();
 
-    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
@@ -501,7 +501,7 @@ Arguments:
 --*/
 {
     NTSTATUS Status = STATUS_INVALID_PARAMETER;
-    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+    DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
     ULONG ValidPowerState = BATTERY_CHARGING |
                       BATTERY_DISCHARGING |
                       BATTERY_CRITICAL |
@@ -536,7 +536,7 @@ Arguments:
 --*/
 {
     NTSTATUS Status = STATUS_INVALID_PARAMETER;
-    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+    DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
     ULONG ValidCapabilities = BATTERY_CAPACITY_RELATIVE |
                         BATTERY_IS_SHORT_TERM |
                         BATTERY_SYSTEM_BATTERY;

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -1,125 +1,652 @@
-#include "Battery.hpp"
-#include "device.hpp"
-#include <Poclass.h> // for IOCTL_BATTERY_QUERY_INFORMATION
+/*++
+    This module implements battery miniclass functionality specific to the
+    simulated battery driver.
+--*/
 
-#if 0
-static void UpdateBatteryInformation(BATTERY_INFORMATION& bi, BatteryState& state) {
-    auto CycleCountBefore = bi.CycleCount;
+#include "battery.hpp"
+//#include "simbattdriverif.h"
 
-    WdfSpinLockAcquire(state.Lock);
-    bi.CycleCount = state.CycleCount;
-    WdfSpinLockRelease(state.Lock);
+//------------------------------------------------------------------- Prototypes
 
-    DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: UpdateBatteryInformation CycleCount before=%u, after=%u\n", CycleCountBefore, bi.CycleCount); CycleCountBefore;
+_IRQL_requires_same_
+void UpdateTag (_Inout_ BATT_FDO_DATA* DevExt);
+
+BCLASS_QUERY_TAG_CALLBACK QueryTag;
+BCLASS_QUERY_INFORMATION_CALLBACK QueryInformation;
+BCLASS_SET_INFORMATION_CALLBACK SetInformation;
+BCLASS_QUERY_STATUS_CALLBACK QueryStatus;
+BCLASS_SET_STATUS_NOTIFY_CALLBACK SetStatusNotify;
+BCLASS_DISABLE_STATUS_NOTIFY_CALLBACK DisableStatusNotify;
+
+_Must_inspect_result_
+_Success_(return==STATUS_SUCCESS)
+NTSTATUS SetBatteryStatus (_In_ WDFDEVICE Device, _In_ BATTERY_STATUS* BatteryStatus);
+
+_Must_inspect_result_
+_Success_(return==STATUS_SUCCESS)
+NTSTATUS SetBatteryInformation (_In_ WDFDEVICE Device, _In_ BATTERY_INFORMATION* BatteryInformation);
+
+//------------------------------------------------------------ Battery Interface
+
+
+NTSTATUS InitializeBattery(_In_ WDFDEVICE Device)
+{
+    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+
+    // Attach to the battery class driver
+    BATTERY_MINIPORT_INFO_V1_1 BattInit = {};
+    BattInit.MajorVersion = BATTERY_CLASS_MAJOR_VERSION;
+    BattInit.MinorVersion = BATTERY_CLASS_MINOR_VERSION_1;
+    BattInit.Context = DevExt;
+    BattInit.QueryTag = QueryTag;
+    BattInit.QueryInformation = QueryInformation;
+    BattInit.SetInformation = SetInformation;
+    BattInit.QueryStatus = QueryStatus;
+    BattInit.SetStatusNotify = SetStatusNotify;
+    BattInit.DisableStatusNotify = DisableStatusNotify;
+    BattInit.Pdo = WdfDeviceWdmGetPhysicalDevice(Device);
+    BattInit.DeviceName = NULL;
+    BattInit.Fdo = WdfDeviceWdmGetDeviceObject(Device);
+
+    WdfWaitLockAcquire(DevExt->ClassInitLock, NULL);
+    NTSTATUS status = BatteryClassInitializeDevice((BATTERY_MINIPORT_INFO*)&BattInit, &DevExt->ClassHandle);
+    WdfWaitLockRelease(DevExt->ClassInitLock);
+
+    return status;
 }
 
-static void UpdateBatteryTemperature(ULONG& temp, BatteryState& state) {
-    auto TempBefore = temp;
+_Use_decl_annotations_
+void InitializeBatteryState (WDFDEVICE Device)
+/*++
+Routine Description:
+    This routine is called to initialize battery data to sane values.
 
-    WdfSpinLockAcquire(state.Lock);
-    temp = state.Temperature;
-    WdfSpinLockRelease(state.Lock);
+    A real battery would query hardware to determine if a battery is present,
+    query its static capabilities, etc.
 
-    // error 0xc0000010 (STATUS_INVALID_DEVICE_REQUEST) observed here
-    DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: UpdateBatteryTemperature before=%u, after=%u\n", TempBefore, temp); TempBefore;
+Arguments:
+    Device - Supplies the device to initialize.
+--*/
+{
+    DebugEnter();
+
+    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+
+    // Get this battery's state - use defaults.
+    {
+        WdfWaitLockAcquire(DevExt->StateLock, NULL);
+        UpdateTag(DevExt);
+
+        // manufactured on 8th September 2024
+        DevExt->State.ManufactureDate.Day = 8;
+        DevExt->State.ManufactureDate.Month = 9;
+        DevExt->State.ManufactureDate.Year = 2024;
+
+        DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY;
+        DevExt->State.BatteryInfo.Technology = 1;
+        DevExt->State.BatteryInfo.Chemistry[0] = 'F';
+        DevExt->State.BatteryInfo.Chemistry[1] = 'a';
+        DevExt->State.BatteryInfo.Chemistry[2] = 'k';
+        DevExt->State.BatteryInfo.Chemistry[3] = 'e';
+        DevExt->State.BatteryInfo.DesignedCapacity = 110;
+        DevExt->State.BatteryInfo.FullChargedCapacity = 100;
+        DevExt->State.BatteryInfo.DefaultAlert1 = 0;
+        DevExt->State.BatteryInfo.DefaultAlert2 = 0;
+        DevExt->State.BatteryInfo.CriticalBias = 0;
+        DevExt->State.BatteryInfo.CycleCount = 100;
+
+        DevExt->State.BatteryStatus.PowerState = BATTERY_POWER_ON_LINE;
+        DevExt->State.BatteryStatus.Capacity = 90;
+        DevExt->State.BatteryStatus.Voltage = BATTERY_UNKNOWN_VOLTAGE;
+        DevExt->State.BatteryStatus.Rate = 0;
+
+        //DevExt->State.GranularityCount = 0;
+        //for (unsigned int i = 0; i < DevExt->State.GranularityCount; ++i) {
+        //    DevExt->State.GranularityScale[i].Granularity = 0; // granularity [mWh]
+        //    DevExt->State.GranularityScale[i].Capacity = 0; // upper capacity limit for Granularity [mWh]
+        //}
+
+        DevExt->State.EstimatedTime = BATTERY_UNKNOWN_TIME; // battery run time, in seconds
+
+        DevExt->State.Temperature = 2981; // 25 degree Celsius [10ths of a degree Kelvin]
+
+        RtlStringCchCopyW(DevExt->State.DeviceName, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery");
+
+        RtlStringCchCopyW(DevExt->State.ManufacturerName, MAX_BATTERY_STRING_SIZE, L"OpenSource");
+
+        RtlStringCchCopyW(DevExt->State.SerialNumber, MAX_BATTERY_STRING_SIZE, L"1234");
+
+        RtlStringCchCopyW(DevExt->State.UniqueId, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery007");
+
+        WdfWaitLockRelease(DevExt->StateLock);
+    }
 }
 
+_Use_decl_annotations_
+void UpdateTag (BATT_FDO_DATA* DevExt)
+/*++
+Routine Description:
+    This routine is called when static battery properties have changed to
+    update the battery tag.
+--*/
+{
+    DevExt->BatteryTag += 1;
+    if (DevExt->BatteryTag == BATTERY_TAG_INVALID) {
+        DevExt->BatteryTag += 1;
+    }
+}
 
-/** IOCTL request completion routine for modifying the output buffer written by the driver beneath. */
-void EvtIoDeviceControlBattFilterCompletion (_In_  WDFREQUEST Request, _In_  WDFIOTARGET Target, _In_  WDF_REQUEST_COMPLETION_PARAMS* Params, _In_  WDFCONTEXT Context) {
-    UNREFERENCED_PARAMETER(Params); // invalidated by WdfRequestFormatRequestUsingCurrentType
+_Use_decl_annotations_
+NTSTATUS QueryTag (void* Context, ULONG* BatteryTag)
+/*++
+Routine Description:
+    This routine is called to get the value of the current battery tag.
+
+Arguments:
+    Context - Supplies the miniport context value for battery
+    BatteryTag - Supplies a pointer to a ULONG to receive the battery tag.
+--*/
+{
+    NTSTATUS Status;
+
+    DebugEnter();
+
+    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    *BatteryTag = DevExt->BatteryTag;
+    WdfWaitLockRelease(DevExt->StateLock);
+    if (*BatteryTag == BATTERY_TAG_INVALID) {
+        Status = STATUS_NO_SUCH_DEVICE;
+    } else {
+        Status = STATUS_SUCCESS;
+    }
+
+    DebugExitStatus(Status);
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS QueryInformation (
+    void* Context,
+    ULONG BatteryTag,
+    BATTERY_QUERY_INFORMATION_LEVEL Level,
+    LONG AtRate,
+    void* Buffer,
+    ULONG BufferLength,
+    ULONG* ReturnedLength)
+/*++
+Routine Description:
+    Called by the class driver to retrieve battery information
+
+    The battery class driver will serialize all requests it issues to
+    the miniport for a given battery.
+
+    Return invalid parameter when a request for a specific level of information
+    can't be handled. This is defined in the battery class spec.
+
+Arguments:
+    Context - Supplies the miniport context value for battery
+
+    BatteryTag - Supplies the tag of current battery
+
+    Level - Supplies the type of information required
+
+    AtRate - Supplies the rate of drain for the BatteryEstimatedTime level
+
+    Buffer - Supplies a pointer to a buffer to place the information
+
+    BufferLength - Supplies the length in bytes of the buffer
+
+    ReturnedLength - Supplies the length in bytes of the returned data
+
+Return Value:
+    Success if there is a battery currently installed, else no such device.
+--*/
+{
+    ULONG ResultValue;
+    NTSTATUS Status;
+
+    UNREFERENCED_PARAMETER(AtRate);
+
+    DebugEnter();
+
+    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    if (BatteryTag != DevExt->BatteryTag) {
+        Status = STATUS_NO_SUCH_DEVICE;
+        goto QueryInformationEnd;
+    }
+
+    // Determine the value of the information being queried for and return it.
+    // In a real battery, this would require hardware/firmware accesses. The
+    // simulated battery fakes this by storing the data to be returned in
+    // memory.
+    void* ReturnBuffer = NULL;
+    size_t ReturnBufferLength = 0;
+    DebugPrint(DPFLTR_INFO_LEVEL, "Query for information level 0x%x\n", Level);
+    Status = STATUS_INVALID_DEVICE_REQUEST;
+    switch (Level) {
+    case BatteryInformation:
+        ReturnBuffer = &DevExt->State.BatteryInfo;
+        ReturnBufferLength = sizeof(BATTERY_INFORMATION);
+        Status = STATUS_SUCCESS;
+        break;
+
+    case BatteryEstimatedTime:
+        if (DevExt->State.EstimatedTime == SIMBATT_RATE_CALCULATE) {
+            if (AtRate == 0) {
+                AtRate = DevExt->State.BatteryStatus.Rate;
+            }
+
+            if (AtRate < 0) {
+                ResultValue = (3600 * DevExt->State.BatteryStatus.Capacity) /
+                                (-AtRate);
+
+            } else {
+                ResultValue = BATTERY_UNKNOWN_TIME;
+            }
+
+        } else {
+            ResultValue = DevExt->State.EstimatedTime;
+        }
+
+        ReturnBuffer = &ResultValue;
+        ReturnBufferLength = sizeof(ResultValue);
+        Status = STATUS_SUCCESS;
+        break;
+
+    case BatteryUniqueID:
+        ReturnBuffer = DevExt->State.UniqueId;
+        Status = RtlStringCbLengthW(DevExt->State.UniqueId,
+                                    sizeof(DevExt->State.UniqueId),
+                                    &ReturnBufferLength);
+
+        ReturnBufferLength += sizeof(WCHAR);
+        break;
+
+    case BatteryManufactureName:
+        ReturnBuffer = DevExt->State.ManufacturerName;
+        Status = RtlStringCbLengthW(DevExt->State.ManufacturerName,
+                                    sizeof(DevExt->State.ManufacturerName),
+                                    &ReturnBufferLength);
+
+        ReturnBufferLength += sizeof(WCHAR);
+        break;
+
+    case BatteryDeviceName:
+        ReturnBuffer = DevExt->State.DeviceName;
+        Status = RtlStringCbLengthW(DevExt->State.DeviceName,
+                                    sizeof(DevExt->State.DeviceName),
+                                    &ReturnBufferLength);
+
+        ReturnBufferLength += sizeof(WCHAR);
+        break;
+
+    case BatterySerialNumber:
+        ReturnBuffer = DevExt->State.SerialNumber;
+        Status = RtlStringCbLengthW(DevExt->State.SerialNumber,
+                                    sizeof(DevExt->State.SerialNumber),
+                                    &ReturnBufferLength);
+
+        ReturnBufferLength += sizeof(WCHAR);
+        break;
+
+    case BatteryManufactureDate:
+        if (DevExt->State.ManufactureDate.Day != 0) {
+            ReturnBuffer = &DevExt->State.ManufactureDate;
+            ReturnBufferLength = sizeof(BATTERY_MANUFACTURE_DATE);
+            Status = STATUS_SUCCESS;
+        }
+
+        break;
+
+    case BatteryGranularityInformation:
+        if (DevExt->State.GranularityCount > 0) {
+            ReturnBuffer = DevExt->State.GranularityScale;
+            ReturnBufferLength = DevExt->State.GranularityCount*sizeof(BATTERY_REPORTING_SCALE);
+
+            Status = STATUS_SUCCESS;
+        }
+
+        break;
+
+    case BatteryTemperature:
+        ReturnBuffer = &DevExt->State.Temperature;
+        ReturnBufferLength = sizeof(ULONG);
+        Status = STATUS_SUCCESS;
+        break;
+
+    default:
+        Status = STATUS_INVALID_PARAMETER;
+        break;
+    }
+
+    NT_ASSERT(((ReturnBufferLength == 0) && (ReturnBuffer == NULL)) ||
+              ((ReturnBufferLength > 0)  && (ReturnBuffer != NULL)));
+
+    if (NT_SUCCESS(Status)) {
+        *ReturnedLength = (ULONG)ReturnBufferLength;
+        if (ReturnBuffer != NULL) {
+            if ((Buffer == NULL) || (BufferLength < ReturnBufferLength)) {
+                Status = STATUS_BUFFER_TOO_SMALL;
+
+            } else {
+                memcpy(Buffer, ReturnBuffer, ReturnBufferLength);
+            }
+        }
+
+    } else {
+        *ReturnedLength = 0;
+    }
+
+QueryInformationEnd:
+    WdfWaitLockRelease(DevExt->StateLock);
+    DebugExitStatus(Status);
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS QueryStatus (void* Context, ULONG BatteryTag, BATTERY_STATUS* BatteryStatus)
+/*++
+Routine Description:
+    Called by the class driver to retrieve the batteries current status
+
+    The battery class driver will serialize all requests it issues to
+    the miniport for a given battery.
+
+Arguments:
+    Context - Supplies the miniport context value for battery
+
+    BatteryTag - Supplies the tag of current battery
+
+    BatteryStatus - Supplies a pointer to the structure to return the current
+        battery status in
+
+Return Value:
+    Success if there is a battery currently installed, else no such device.
+--*/
+{
+    NTSTATUS Status;
+
+    DebugEnter();
+
+    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    if (BatteryTag != DevExt->BatteryTag) {
+        Status = STATUS_NO_SUCH_DEVICE;
+        goto QueryStatusEnd;
+    }
+
+    RtlCopyMemory(BatteryStatus,
+                  &DevExt->State.BatteryStatus,
+                  sizeof(BATTERY_STATUS));
+
+    Status = STATUS_SUCCESS;
+
+QueryStatusEnd:
+    WdfWaitLockRelease(DevExt->StateLock);
+    DebugExitStatus(Status);
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS SetStatusNotify (void* Context, ULONG BatteryTag, BATTERY_NOTIFY* BatteryNotify)
+/*++
+Routine Description:
+    Called by the class driver to set the capacity and power state levels
+    at which the class driver requires notification.
+
+    The battery class driver will serialize all requests it issues to
+    the miniport for a given battery.
+
+Arguments:
+    Context - Supplies the miniport context value for battery
+
+    BatteryTag - Supplies the tag of current battery
+
+    BatteryNotify - Supplies a pointer to a structure containing the
+        notification critera.
+
+Return Value:
+    Success if there is a battery currently installed, else no such device.
+--*/
+{
+    NTSTATUS Status;
+
+    UNREFERENCED_PARAMETER(BatteryNotify);
+
+    DebugEnter();
+
+    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    if (BatteryTag != DevExt->BatteryTag) {
+        Status = STATUS_NO_SUCH_DEVICE;
+        goto SetStatusNotifyEnd;
+    }
+
+    Status = STATUS_NOT_SUPPORTED;
+
+SetStatusNotifyEnd:
+    WdfWaitLockRelease(DevExt->StateLock);
+    DebugExitStatus(Status);
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS DisableStatusNotify (void* Context)
+/*++
+Routine Description:
+    Called by the class driver to disable notification.
+
+    The battery class driver will serialize all requests it issues to
+    the miniport for a given battery.
+
+Arguments:
+    Context - Supplies the miniport context value for battery
+
+Return Value:
+    Success if there is a battery currently installed, else no such device.
+--*/
+{
     UNREFERENCED_PARAMETER(Context);
 
-    REQUEST_CONTEXT* reqCtx = WdfObjectGet_REQUEST_CONTEXT(Request);
+    DebugEnter();
 
-    if (!NT_SUCCESS(WdfRequestGetStatus(Request))) {
-        if ((reqCtx->IoControlCode == IOCTL_BATTERY_QUERY_INFORMATION) && (reqCtx->InformationLevel == BatteryTemperature) && (WdfRequestGetStatus(Request) == STATUS_INVALID_DEVICE_REQUEST)) {
-            // continue despite IOCTL_BATTERY_QUERY_INFORMATION BatteryTemperature failure to filter query
-        } else {
-            //DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: BattFilterCompletion IOCTL=0x%x, status=0x%x"), reqCtx->IoControlCode, WdfRequestGetStatus(Request));
-            WdfRequestComplete(Request, WdfRequestGetStatus(Request));
-            return;
-        }
-    }
-
-    if (reqCtx->IoControlCode != IOCTL_BATTERY_QUERY_INFORMATION) {
-        // don't touch other IOCTL codes
-        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
-        return;
-    }
-
-    WDFDEVICE Device = WdfIoTargetGetDevice(Target);
-    DEVICE_CONTEXT* context = WdfObjectGet_DEVICE_CONTEXT(Device);
-
-    // use WdfRequestRetrieveOutputBuffer since the Params argument have been invalidated by WdfRequestFormatRequestUsingCurrentType
-    void* OutputBuffer = nullptr;
-    size_t OutputBufferLength = 0;
-    NTSTATUS status = WdfRequestRetrieveOutputBuffer(Request, 0, (void**)&OutputBuffer, &OutputBufferLength);
-    if (!NT_SUCCESS(status)) {
-        // no output buffer to modify
-        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
-        return;
-    }
-
-    //DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: BattFilterCompletion: IOCTL_BATTERY_QUERY_INFORMATION (InformationLevel=%u, OutputBufferLength=%u, Information=%u, Status=0x%x)\n", reqCtx->InformationLevel, OutputBufferLength, WdfRequestGetInformation(Request), WdfRequestGetStatus(Request));
-
-    if ((reqCtx->InformationLevel == BatteryInformation) && (OutputBufferLength >= sizeof(BATTERY_INFORMATION))) {
-        auto* bi = (BATTERY_INFORMATION*)OutputBuffer;
-        UpdateBatteryInformation(*bi, *context->Interface.State);
-    } else if ((reqCtx->InformationLevel == BatteryTemperature) && (OutputBufferLength >= sizeof(ULONG))) {
-        auto* temp = (ULONG*)OutputBuffer;
-        UpdateBatteryTemperature(*temp, *context->Interface.State);
-        if (WdfRequestGetStatus(Request) == STATUS_INVALID_DEVICE_REQUEST) {
-            // fix failing query by making status succeed and increase output size
-            WdfRequestCompleteWithInformation(Request, STATUS_SUCCESS, sizeof(ULONG));
-            return;
-        }
-    }
-
-    WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    NTSTATUS Status = STATUS_NOT_SUPPORTED;
+    DebugExitStatus(Status);
+    return Status;
 }
 
+_Use_decl_annotations_
+NTSTATUS SetInformation (
+    void* Context,
+    ULONG BatteryTag,
+    BATTERY_SET_INFORMATION_LEVEL Level,
+    void* Buffer)
+/*
+ Routine Description:
+    Called by the class driver to set the battery's charge/discharge state,
+    critical bias, or charge current.
 
-_Function_class_(EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL)
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-VOID EvtIoDeviceControlBattFilter(
-    _In_  WDFQUEUE          Queue,
-    _In_  WDFREQUEST        Request,
-    _In_  size_t            OutputBufferLength,
-    _In_  size_t            InputBufferLength,
-    _In_  ULONG             IoControlCode) {
-#if 0
-    DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: EvtIoDeviceControlBattFilter (IoControlCode=0x%x, InputBufferLength=%Iu, OutputBufferLength=%Iu)\n", IoControlCode, InputBufferLength, OutputBufferLength);
-#endif
-    UNREFERENCED_PARAMETER(OutputBufferLength);
+Arguments:
+    Context - Supplies the miniport context value for battery
 
-    WDFDEVICE Device = WdfIoQueueGetDevice(Queue);
-    REQUEST_CONTEXT* reqCtx = WdfObjectGet_REQUEST_CONTEXT(Request);
+    BatteryTag - Supplies the tag of current battery
 
-    // update completion context with IOCTL buffer information
-    if ((IoControlCode == IOCTL_BATTERY_QUERY_INFORMATION) && (InputBufferLength == sizeof(BATTERY_QUERY_INFORMATION))) {
-        // capture InformationLevel from input buffer
-        BATTERY_QUERY_INFORMATION* InputBuffer = nullptr;
-        NTSTATUS status = WdfRequestRetrieveInputBuffer(Request, 0, (void**)&InputBuffer, nullptr);
-        NT_ASSERTMSG("WdfRequestRetrieveInputBuffer failed", NT_SUCCESS(status)); status;
+    Level - Supplies action requested
 
-        reqCtx->Set(IoControlCode, InputBuffer->InformationLevel);
+    Buffer - Supplies a critical bias value if level is BatteryCriticalBias.
+--*/
+{
+    NTSTATUS Status;
+    UNREFERENCED_PARAMETER(Level);
+
+    DebugEnter();
+
+    BATT_FDO_DATA* DevExt = (BATT_FDO_DATA*)Context;
+    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    if (BatteryTag != DevExt->BatteryTag) {
+        Status = STATUS_NO_SUCH_DEVICE;
+        goto SetInformationEnd;
+    }
+
+    if (Buffer == NULL) {
+        Status = STATUS_INVALID_PARAMETER_4;
     } else {
-        reqCtx->Set(IoControlCode, 0);
+        Status = STATUS_NOT_SUPPORTED;
     }
 
-    // Formating required if specifying a completion routine
-    WdfRequestFormatRequestUsingCurrentType(Request);
-    // set completion callback
-    WdfRequestSetCompletionRoutine(Request, EvtIoDeviceControlBattFilterCompletion, nullptr);
-
-    // Forward the request down the driver stack
-    BOOLEAN ret = WdfRequestSend(Request, WdfDeviceGetIoTarget(Device), WDF_NO_SEND_OPTIONS);
-    if (ret == FALSE) {
-        NTSTATUS status = WdfRequestGetStatus(Request);
-        DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfRequestSend failed with status: 0x%x"), status);
-        WdfRequestComplete(Request, status);
-    }
+SetInformationEnd:
+    WdfWaitLockRelease(DevExt->StateLock);
+    DebugExitStatus(Status);
+    return Status;
 }
-#endif
+
+//------------------------------------------------- Battery Simulation Interface
+//
+// The following IO control handler and associated SimBattSetXxx routines
+// implement the control side of the simulated battery. A real battery would
+// not implement this interface, and instead read battery data from hardware/
+// firmware interfaces.
+void BattIoDeviceControl (
+    WDFQUEUE Queue,
+    WDFREQUEST Request,
+    size_t OutputBufferLength,
+    size_t InputBufferLength,
+    ULONG IoControlCode)
+/*++
+Routine Description:
+    Handle changes to the simulated battery state.
+
+Arguments:
+    Queue - Supplies a handle to the framework queue object that is associated
+        with the I/O request.
+
+    Request - Supplies a handle to a framework request object. This one
+        represents the IRP_MJ_DEVICE_CONTROL IRP received by the framework.
+
+    OutputBufferLength - Supplies the length, in bytes, of the request's output
+        buffer, if an output buffer is available.
+
+    InputBufferLength - Supplies the length, in bytes, of the request's input
+        buffer, if an input buffer is available.
+
+    IoControlCode - Supplies the Driver-defined or system-defined I/O control
+        code (IOCTL) that is associated with the request.
+--*/
+{
+    BATTERY_INFORMATION* BatteryInformation;
+    BATTERY_STATUS* BatteryStatus;
+    size_t Length;
+    NTSTATUS TempStatus;
+
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    ULONG BytesReturned = 0;
+    WDFDEVICE Device = WdfIoQueueGetDevice(Queue);
+    DebugPrint(DPFLTR_INFO_LEVEL, "BattIoDeviceControl: 0x%p\n", Device);
+    NTSTATUS Status = STATUS_INVALID_PARAMETER;
+    switch (IoControlCode) {
+    case IOCTL_SIMBATT_SET_STATUS:
+        TempStatus = WdfRequestRetrieveInputBuffer(Request, sizeof(BATTERY_STATUS), (void**)&BatteryStatus, &Length);
+
+        if (NT_SUCCESS(TempStatus) && (Length == sizeof(BATTERY_STATUS))) {
+            Status = SetBatteryStatus(Device, BatteryStatus);
+        }
+
+        break;
+
+    case IOCTL_SIMBATT_SET_INFORMATION:
+        TempStatus = WdfRequestRetrieveInputBuffer(Request, sizeof(BATTERY_INFORMATION), (void**)&BatteryInformation, &Length);
+
+        if (NT_SUCCESS(TempStatus) && (Length == sizeof(BATTERY_INFORMATION))) {
+            Status = SetBatteryInformation(Device, BatteryInformation);
+        }
+
+        break;
+
+    default:
+        break;
+    }
+
+    WdfRequestCompleteWithInformation(Request, Status, BytesReturned);
+}
+
+_Use_decl_annotations_
+NTSTATUS SetBatteryStatus (WDFDEVICE Device, BATTERY_STATUS* BatteryStatus)
+/*++
+Routine Description:
+    Set the simulated battery status structure values.
+
+Arguments:
+    Device - Supplies the device to set data for.
+
+    BatteryStatus - Supplies the new status data to set.
+--*/
+{
+    NTSTATUS Status = STATUS_INVALID_PARAMETER;
+    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+    ULONG ValidPowerState = BATTERY_CHARGING |
+                      BATTERY_DISCHARGING |
+                      BATTERY_CRITICAL |
+                      BATTERY_POWER_ON_LINE;
+
+    if ((BatteryStatus->PowerState & ~ValidPowerState) != 0) {
+        goto SetBatteryStatusEnd;
+    }
+
+    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    static_assert(sizeof(DevExt->State.BatteryStatus) == sizeof(*BatteryStatus));
+    RtlCopyMemory(&DevExt->State.BatteryStatus, BatteryStatus, sizeof(BATTERY_STATUS));
+    WdfWaitLockRelease(DevExt->StateLock);
+
+    BatteryClassStatusNotify(DevExt->ClassHandle);
+    Status = STATUS_SUCCESS;
+
+SetBatteryStatusEnd:
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS SetBatteryInformation (WDFDEVICE Device, BATTERY_INFORMATION* BatteryInformation)
+/*++
+Routine Description:
+    Set the simulated battery information structure values.
+
+Arguments:
+    Device - Supplies the device to set data for.
+
+    BatteryInformation - Supplies the new information data to set.
+--*/
+{
+    NTSTATUS Status = STATUS_INVALID_PARAMETER;
+    BATT_FDO_DATA* DevExt = GetDeviceExtension(Device);
+    ULONG ValidCapabilities = BATTERY_CAPACITY_RELATIVE |
+                        BATTERY_IS_SHORT_TERM |
+                        BATTERY_SYSTEM_BATTERY;
+
+    if ((BatteryInformation->Capabilities & ~ValidCapabilities) != 0) {
+        goto SetBatteryInformationEnd;
+    }
+
+    if (BatteryInformation->Technology > 1) {
+        goto SetBatteryInformationEnd;
+    }
+
+    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    static_assert(sizeof(DevExt->State.BatteryInfo) == sizeof(*BatteryInformation));
+    RtlCopyMemory(&DevExt->State.BatteryInfo, BatteryInformation, sizeof(BATTERY_INFORMATION));
+
+    // To indicate that battery information has changed, update the battery tag
+    // and notify the class driver that the battery status has updated. The
+    // status query will fail due to a different battery tag, causing the class
+    // driver to query for the new tag and new information.
+    UpdateTag(DevExt);
+    WdfWaitLockRelease(DevExt->StateLock);
+    BatteryClassStatusNotify(DevExt->ClassHandle);
+    Status = STATUS_SUCCESS;
+
+SetBatteryInformationEnd:
+    return Status;
+}

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -99,10 +99,10 @@ Arguments:
 
         DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY;
         DevExt->State.BatteryInfo.Technology = 1;
-        DevExt->State.BatteryInfo.Chemistry[0] = 'F';
-        DevExt->State.BatteryInfo.Chemistry[1] = 'a';
-        DevExt->State.BatteryInfo.Chemistry[2] = 'k';
-        DevExt->State.BatteryInfo.Chemistry[3] = 'e';
+
+        for (size_t i = 0; i < 4; i++)
+            DevExt->State.BatteryInfo.Chemistry[i] = 0;
+
         DevExt->State.BatteryInfo.DesignedCapacity = 0;
         DevExt->State.BatteryInfo.FullChargedCapacity = 0;
         DevExt->State.BatteryInfo.DefaultAlert1 = 0;

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -90,7 +90,7 @@ Arguments:
 
     // Get this battery's state - use defaults.
     {
-        WdfWaitLockAcquire(DevExt->StateLock, NULL);
+        WdfWaitLockAcquire(DevExt->State.Lock, NULL);
         UpdateTag(DevExt);
 
         // manufactured on 8th September 2024
@@ -134,7 +134,7 @@ Arguments:
 
         RtlStringCchCopyW(DevExt->State.UniqueId, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery007");
 
-        WdfWaitLockRelease(DevExt->StateLock);
+        WdfWaitLockRelease(DevExt->State.Lock);
     }
 }
 
@@ -168,9 +168,9 @@ Arguments:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
     *BatteryTag = DevExt->BatteryTag;
-    WdfWaitLockRelease(DevExt->StateLock);
+    WdfWaitLockRelease(DevExt->State.Lock);
     if (*BatteryTag == BATTERY_TAG_INVALID) {
         Status = STATUS_NO_SUCH_DEVICE;
     } else {
@@ -227,7 +227,7 @@ Return Value:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto QueryInformationEnd;
@@ -341,7 +341,7 @@ Return Value:
     }
 
 QueryInformationEnd:
-    WdfWaitLockRelease(DevExt->StateLock);
+    WdfWaitLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -372,7 +372,7 @@ Return Value:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto QueryStatusEnd;
@@ -385,7 +385,7 @@ Return Value:
     Status = STATUS_SUCCESS;
 
 QueryStatusEnd:
-    WdfWaitLockRelease(DevExt->StateLock);
+    WdfWaitLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -419,7 +419,7 @@ Return Value:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto SetStatusNotifyEnd;
@@ -428,7 +428,7 @@ Return Value:
     Status = STATUS_NOT_SUPPORTED;
 
 SetStatusNotifyEnd:
-    WdfWaitLockRelease(DevExt->StateLock);
+    WdfWaitLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -485,7 +485,7 @@ Arguments:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto SetInformationEnd;
@@ -498,7 +498,7 @@ Arguments:
     }
 
 SetInformationEnd:
-    WdfWaitLockRelease(DevExt->StateLock);
+    WdfWaitLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -526,10 +526,10 @@ Arguments:
         goto SetBatteryStatusEnd;
     }
 
-    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
     static_assert(sizeof(DevExt->State.BatteryStatus) == sizeof(*BatteryStatus));
     RtlCopyMemory(&DevExt->State.BatteryStatus, BatteryStatus, sizeof(BATTERY_STATUS));
-    WdfWaitLockRelease(DevExt->StateLock);
+    WdfWaitLockRelease(DevExt->State.Lock);
 
     BatteryClassStatusNotify(DevExt->ClassHandle);
     Status = STATUS_SUCCESS;
@@ -564,7 +564,7 @@ Arguments:
         goto SetBatteryInformationEnd;
     }
 
-    WdfWaitLockAcquire(DevExt->StateLock, NULL);
+    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
     static_assert(sizeof(DevExt->State.BatteryInfo) == sizeof(*BatteryInformation));
     RtlCopyMemory(&DevExt->State.BatteryInfo, BatteryInformation, sizeof(BATTERY_INFORMATION));
 
@@ -573,7 +573,7 @@ Arguments:
     // status query will fail due to a different battery tag, causing the class
     // driver to query for the new tag and new information.
     UpdateTag(DevExt);
-    WdfWaitLockRelease(DevExt->StateLock);
+    WdfWaitLockRelease(DevExt->State.Lock);
     BatteryClassStatusNotify(DevExt->ClassHandle);
     Status = STATUS_SUCCESS;
 

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -30,7 +30,7 @@ NTSTATUS SetBatteryInformation (_In_ WDFDEVICE Device, _In_ BATTERY_INFORMATION*
 //------------------------------------------------------------ Battery Interface
 
 
-NTSTATUS InitializeBattery(_In_ WDFDEVICE Device)
+NTSTATUS InitializeBatteryClass(_In_ WDFDEVICE Device)
 {
     DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
 
@@ -53,6 +53,21 @@ NTSTATUS InitializeBattery(_In_ WDFDEVICE Device)
     NTSTATUS status = BatteryClassInitializeDevice((BATTERY_MINIPORT_INFO*)&BattInit, &DevExt->ClassHandle);
     WdfWaitLockRelease(DevExt->ClassInitLock);
 
+    return status;
+}
+
+NTSTATUS UnloadBatteryClass(_In_ WDFDEVICE Device)
+{
+    DEVICE_CONTEXT* DevExt = WdfObjectGet_DEVICE_CONTEXT(Device);
+    WdfWaitLockAcquire(DevExt->ClassInitLock, NULL);
+
+    NTSTATUS status = STATUS_SUCCESS;
+    if (DevExt->ClassHandle != NULL) {
+        status = BatteryClassUnload(DevExt->ClassHandle);
+        DevExt->ClassHandle = NULL;
+    }
+
+    WdfWaitLockRelease(DevExt->ClassInitLock);
     return status;
 }
 

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -90,7 +90,7 @@ Arguments:
 
     // Get this battery's state - use defaults.
     {
-        WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+        WdfSpinLockAcquire(DevExt->State.Lock);
         UpdateTag(DevExt);
 
         // manufactured on 8th September 2024
@@ -134,7 +134,7 @@ Arguments:
 
         RtlStringCchCopyW(DevExt->State.UniqueId, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery007");
 
-        WdfWaitLockRelease(DevExt->State.Lock);
+        WdfSpinLockRelease(DevExt->State.Lock);
     }
 }
 
@@ -168,9 +168,9 @@ Arguments:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+    WdfSpinLockAcquire(DevExt->State.Lock);
     *BatteryTag = DevExt->BatteryTag;
-    WdfWaitLockRelease(DevExt->State.Lock);
+    WdfSpinLockRelease(DevExt->State.Lock);
     if (*BatteryTag == BATTERY_TAG_INVALID) {
         Status = STATUS_NO_SUCH_DEVICE;
     } else {
@@ -227,7 +227,7 @@ Return Value:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+    WdfSpinLockAcquire(DevExt->State.Lock);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto QueryInformationEnd;
@@ -341,7 +341,7 @@ Return Value:
     }
 
 QueryInformationEnd:
-    WdfWaitLockRelease(DevExt->State.Lock);
+    WdfSpinLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -372,7 +372,7 @@ Return Value:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+    WdfSpinLockAcquire(DevExt->State.Lock);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto QueryStatusEnd;
@@ -385,7 +385,7 @@ Return Value:
     Status = STATUS_SUCCESS;
 
 QueryStatusEnd:
-    WdfWaitLockRelease(DevExt->State.Lock);
+    WdfSpinLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -419,7 +419,7 @@ Return Value:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+    WdfSpinLockAcquire(DevExt->State.Lock);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto SetStatusNotifyEnd;
@@ -428,7 +428,7 @@ Return Value:
     Status = STATUS_NOT_SUPPORTED;
 
 SetStatusNotifyEnd:
-    WdfWaitLockRelease(DevExt->State.Lock);
+    WdfSpinLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -485,7 +485,7 @@ Arguments:
     DebugEnter();
 
     DEVICE_CONTEXT* DevExt = (DEVICE_CONTEXT*)Context;
-    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+    WdfSpinLockAcquire(DevExt->State.Lock);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;
         goto SetInformationEnd;
@@ -498,7 +498,7 @@ Arguments:
     }
 
 SetInformationEnd:
-    WdfWaitLockRelease(DevExt->State.Lock);
+    WdfSpinLockRelease(DevExt->State.Lock);
     DebugExitStatus(Status);
     return Status;
 }
@@ -526,10 +526,10 @@ Arguments:
         goto SetBatteryStatusEnd;
     }
 
-    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+    WdfSpinLockAcquire(DevExt->State.Lock);
     static_assert(sizeof(DevExt->State.BatteryStatus) == sizeof(*BatteryStatus));
     RtlCopyMemory(&DevExt->State.BatteryStatus, BatteryStatus, sizeof(BATTERY_STATUS));
-    WdfWaitLockRelease(DevExt->State.Lock);
+    WdfSpinLockRelease(DevExt->State.Lock);
 
     BatteryClassStatusNotify(DevExt->ClassHandle);
     Status = STATUS_SUCCESS;
@@ -564,7 +564,7 @@ Arguments:
         goto SetBatteryInformationEnd;
     }
 
-    WdfWaitLockAcquire(DevExt->State.Lock, NULL);
+    WdfSpinLockAcquire(DevExt->State.Lock);
     static_assert(sizeof(DevExt->State.BatteryInfo) == sizeof(*BatteryInformation));
     RtlCopyMemory(&DevExt->State.BatteryInfo, BatteryInformation, sizeof(BATTERY_INFORMATION));
 
@@ -573,7 +573,7 @@ Arguments:
     // status query will fail due to a different battery tag, causing the class
     // driver to query for the new tag and new information.
     UpdateTag(DevExt);
-    WdfWaitLockRelease(DevExt->State.Lock);
+    WdfSpinLockRelease(DevExt->State.Lock);
     BatteryClassStatusNotify(DevExt->ClassHandle);
     Status = STATUS_SUCCESS;
 

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -4,6 +4,7 @@
 --*/
 
 #include "battery.hpp"
+#include "device.hpp"
 //#include "simbattdriverif.h"
 
 //------------------------------------------------------------------- Prototypes

--- a/HidBattExt/Battery.cpp
+++ b/HidBattExt/Battery.cpp
@@ -98,7 +98,7 @@ Arguments:
         DevExt->State.ManufactureDate.Year = 0;
 
         DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY;
-        DevExt->State.BatteryInfo.Technology = 1;
+        DevExt->State.BatteryInfo.Technology = 1; // rechargeable
 
         for (size_t i = 0; i < 4; i++)
             DevExt->State.BatteryInfo.Chemistry[i] = 0;

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -22,7 +22,8 @@ struct BATT_STATE {
 };
 
 
-NTSTATUS InitializeBattery(_In_ WDFDEVICE Device);
+NTSTATUS InitializeBatteryClass(_In_ WDFDEVICE Device);
+NTSTATUS UnloadBatteryClass(_In_ WDFDEVICE Device);
 
 _IRQL_requires_same_
 void InitializeBatteryState(_In_ WDFDEVICE Device);

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -21,20 +21,6 @@ struct BATT_STATE {
     WCHAR                           UniqueId[MAX_BATTERY_STRING_SIZE];
 };
 
-struct BATT_FDO_DATA {
-    // Battery class registration
-    void* ClassHandle;
-    WDFWAITLOCK                     ClassInitLock;
-    WMILIB_CONTEXT                  WmiLibContext;
-
-    // Battery state
-    WDFWAITLOCK                     StateLock;
-    ULONG                           BatteryTag;
-    BATT_STATE                   State;
-};
-
-WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(BATT_FDO_DATA, GetDeviceExtension);
-
 
 NTSTATUS InitializeBattery(_In_ WDFDEVICE Device);
 

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -41,5 +41,3 @@ NTSTATUS InitializeBattery(_In_ WDFDEVICE Device);
 
 _IRQL_requires_same_
 void InitializeBatteryState(_In_ WDFDEVICE Device);
-
-EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL BattIoDeviceControl;

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -1,11 +1,10 @@
 #pragma once
 #include <ntddk.h>
 #include <wdf.h>
+#include <Wmilib.h>
 extern "C" {
 #include <Batclass.h>
 }
-#include <Wmilib.h>
-#include "device.hpp"
 
 
 struct BATT_STATE {

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -8,7 +8,7 @@ extern "C" {
 
 
 struct BATT_STATE {
-    WDFWAITLOCK              Lock; // protects state changes
+    WDFSPINLOCK              Lock; // protects state changes
 
     BATTERY_MANUFACTURE_DATE ManufactureDate;
     BATTERY_INFORMATION      BatteryInfo;

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -27,3 +27,6 @@ NTSTATUS UnloadBatteryClass(_In_ WDFDEVICE Device);
 
 _IRQL_requires_same_
 void InitializeBatteryState(_In_ WDFDEVICE Device);
+
+EVT_WDFDEVICE_WDM_IRP_PREPROCESS BattWdmIrpPreprocessDeviceControl;
+EVT_WDFDEVICE_WDM_IRP_PREPROCESS BattWdmIrpPreprocessSystemControl;

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -1,6 +1,45 @@
 #pragma once
 #include <ntddk.h>
 #include <wdf.h>
+extern "C" {
+#include <Batclass.h>
+}
+#include <Wmilib.h>
+#include "device.hpp"
 
 
-EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL EvtIoDeviceControlBattFilter;
+struct BATT_STATE {
+    BATTERY_MANUFACTURE_DATE        ManufactureDate;
+    BATTERY_INFORMATION             BatteryInfo;
+    BATTERY_STATUS                  BatteryStatus;
+    ULONG                           GranularityCount;
+    BATTERY_REPORTING_SCALE         GranularityScale[4];
+    ULONG                           EstimatedTime;
+    ULONG                           Temperature;
+    WCHAR                           DeviceName[MAX_BATTERY_STRING_SIZE];
+    WCHAR                           ManufacturerName[MAX_BATTERY_STRING_SIZE];
+    WCHAR                           SerialNumber[MAX_BATTERY_STRING_SIZE];
+    WCHAR                           UniqueId[MAX_BATTERY_STRING_SIZE];
+};
+
+struct BATT_FDO_DATA {
+    // Battery class registration
+    void* ClassHandle;
+    WDFWAITLOCK                     ClassInitLock;
+    WMILIB_CONTEXT                  WmiLibContext;
+
+    // Battery state
+    WDFWAITLOCK                     StateLock;
+    ULONG                           BatteryTag;
+    BATT_STATE                   State;
+};
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(BATT_FDO_DATA, GetDeviceExtension);
+
+
+NTSTATUS InitializeBattery(_In_ WDFDEVICE Device);
+
+_IRQL_requires_same_
+void InitializeBatteryState(_In_ WDFDEVICE Device);
+
+EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL BattIoDeviceControl;

--- a/HidBattExt/Battery.hpp
+++ b/HidBattExt/Battery.hpp
@@ -8,17 +8,19 @@ extern "C" {
 
 
 struct BATT_STATE {
-    BATTERY_MANUFACTURE_DATE        ManufactureDate;
-    BATTERY_INFORMATION             BatteryInfo;
-    BATTERY_STATUS                  BatteryStatus;
-    ULONG                           GranularityCount;
-    BATTERY_REPORTING_SCALE         GranularityScale[4];
-    ULONG                           EstimatedTime;
-    ULONG                           Temperature;
-    WCHAR                           DeviceName[MAX_BATTERY_STRING_SIZE];
-    WCHAR                           ManufacturerName[MAX_BATTERY_STRING_SIZE];
-    WCHAR                           SerialNumber[MAX_BATTERY_STRING_SIZE];
-    WCHAR                           UniqueId[MAX_BATTERY_STRING_SIZE];
+    WDFWAITLOCK              Lock; // protects state changes
+
+    BATTERY_MANUFACTURE_DATE ManufactureDate;
+    BATTERY_INFORMATION      BatteryInfo;
+    BATTERY_STATUS           BatteryStatus;
+    ULONG                    GranularityCount;
+    BATTERY_REPORTING_SCALE  GranularityScale[4];
+    ULONG                    EstimatedTime;
+    ULONG                    Temperature;
+    WCHAR                    DeviceName[MAX_BATTERY_STRING_SIZE];
+    WCHAR                    ManufacturerName[MAX_BATTERY_STRING_SIZE];
+    WCHAR                    SerialNumber[MAX_BATTERY_STRING_SIZE];
+    WCHAR                    UniqueId[MAX_BATTERY_STRING_SIZE];
 };
 
 

--- a/HidBattExt/HidBattExt.inx
+++ b/HidBattExt/HidBattExt.inx
@@ -32,15 +32,13 @@ HidBattExt.sys = 1
 
 ; Install Section
 [HidBattExt_Inst.NT]
-Include = HidBatt.inf
-Needs = HidBatt_Inst
+Include = battery.inf
+Needs = Battery_Inst
 CopyFiles = @HidBattExt.sys
 
 [HidBattExt_Inst.NT.HW]
 
 [HidBattExt_Inst.NT.Services]
-Include = HidBatt.inf
-Needs = HidBatt_Inst.Services
 AddService = HidBattExt, %SPSVCINST_ASSOCSERVICE%, HidBattExt_Service_Inst
 
 [HidBattExt_Service_Inst]

--- a/HidBattExt/HidBattExt.inx
+++ b/HidBattExt/HidBattExt.inx
@@ -1,5 +1,5 @@
 ;/*++
-; HidBatt extension filter driver - https://github.com/forderud/HidBattery/
+; HidBatt replacement driver - https://github.com/forderud/HidBattery/
 ;
 ; Require Windows 10 build 16299 (1709) or newer due to DefaultDestDir=13 usage.
 ;--*/
@@ -37,16 +37,11 @@ Needs = HidBatt_Inst
 CopyFiles = @HidBattExt.sys
 
 [HidBattExt_Inst.NT.HW]
-AddReg = HidBattExt_Inst.AddReg
-
-[HidBattExt_Inst.AddReg]
-HKR,,"UpperFilters", %REG_TYPE_MULTI_SZ%, "HidBattExt"
-HKR,,"LowerFilters", %REG_TYPE_MULTI_SZ%, "HidBattExt"
 
 [HidBattExt_Inst.NT.Services]
 Include = HidBatt.inf
 Needs = HidBatt_Inst.Services
-AddService = HidBattExt, , HidBattExt_Service_Inst
+AddService = HidBattExt, %SPSVCINST_ASSOCSERVICE%, HidBattExt_Service_Inst
 
 [HidBattExt_Service_Inst]
 ServiceType   = %SERVICE_KERNEL_DRIVER%

--- a/HidBattExt/HidBattExt.inx
+++ b/HidBattExt/HidBattExt.inx
@@ -39,6 +39,8 @@ CopyFiles = @HidBattExt.sys
 [HidBattExt_Inst.NT.HW]
 
 [HidBattExt_Inst.NT.Services]
+Include = battery.inf
+;Needs = Battery_Inst.Services
 AddService = HidBattExt, %SPSVCINST_ASSOCSERVICE%, HidBattExt_Service_Inst
 
 [HidBattExt_Service_Inst]

--- a/HidBattExt/HidBattExt.vcxproj
+++ b/HidBattExt/HidBattExt.vcxproj
@@ -81,7 +81,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib;Ntstrsafe.lib;battc.lib</AdditionalDependencies>
       <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
@@ -94,7 +94,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib;Ntstrsafe.lib;battc.lib</AdditionalDependencies>
       <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
@@ -107,7 +107,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib;Ntstrsafe.lib;battc.lib</AdditionalDependencies>
       <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
@@ -120,7 +120,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib;Ntstrsafe.lib;battc.lib</AdditionalDependencies>
       <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>

--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -289,6 +289,7 @@ NTSTATUS InitializeHidState(_In_ WDFDEVICE Device) {
         // We will let the framework to respond automatically to the pnp state changes of the target by closing and opening the handle.
         openParams.ShareAccess = FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE;
 
+        // WdfIoTargetOpen(PDO) fails with 0xc0000043 (STATUS_SHARING_VIOLATION) if forgetting to specify FILE_SHARE_DELETE
         status = WdfIoTargetOpen(pdoTarget, &openParams);
         if (!NT_SUCCESS(status)) {
             DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfIoTargetOpen failed 0x%x"), status);

--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -564,7 +564,7 @@ _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID EvtIoReadHidFilter(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request, _In_ size_t Length) {
     UNREFERENCED_PARAMETER(Length);
-    //DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: EvtIoReadFilter (Length=%Iu)\n", Length);
+    DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: EvtIoReadHidFilter (Length=%Iu)\n", Length);
 
     WDFDEVICE device = WdfIoQueueGetDevice(Queue);
 

--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -390,6 +390,12 @@ NTSTATUS InitializeHidState(_In_ WDFDEVICE Device) {
             DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfIoTargetOpen failed 0x%x"), status);
             return status;
         }
+
+#if DBG
+        FILE_OBJECT* file = WdfIoTargetWdmGetTargetFileObject(pdoTarget);
+        DebugPrint(DPFLTR_WARNING_LEVEL, "HidBattExt: InitializeHidState FsContext=%p, FsContext2=%p\n", file->FsContext, file->FsContext2);
+        ASSERTMSG("HidBattExt: FsContext null", file->FsContext);
+#endif
     }
 
     HID_COLLECTION_INFORMATION collectionInfo = {};
@@ -398,7 +404,7 @@ NTSTATUS InitializeHidState(_In_ WDFDEVICE Device) {
         WDF_MEMORY_DESCRIPTOR outputDesc = {};
         WDF_MEMORY_DESCRIPTOR_INIT_BUFFER(&outputDesc, &collectionInfo, sizeof(HID_COLLECTION_INFORMATION));
 
-        NTSTATUS status = WdfIoTargetSendIoctlSynchronously(pdoTarget, NULL,
+        NTSTATUS status = WdfIoTargetSendIoctlSynchronously(localTarget, NULL,
             IOCTL_HID_GET_COLLECTION_INFORMATION,
             NULL, // input
             &outputDesc, // output
@@ -427,7 +433,7 @@ NTSTATUS InitializeHidState(_In_ WDFDEVICE Device) {
         WDF_MEMORY_DESCRIPTOR_INIT_HANDLE(&outputDesc, context->Hid.Preparsed, NULL);
 
         // populate "preparsedData"
-        status = WdfIoTargetSendIoctlSynchronously(pdoTarget, NULL,
+        status = WdfIoTargetSendIoctlSynchronously(localTarget, NULL,
             IOCTL_HID_GET_COLLECTION_DESCRIPTOR, // same as HidD_GetPreparsedData in user-mode
             NULL, // input
             &outputDesc, // output

--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -174,6 +174,97 @@ static void UpdateBatteryState(BATT_STATE& state, HIDP_REPORT_TYPE reportType, C
 }
 
 
+/** Alternaive WdfIoTargetSendIoctlSynchronously implementation that can also propagates FileObject permissions after formatting the request. */
+NTSTATUS SendIoctlSynchronouslyExt(WDFIOTARGET target, WDFREQUEST request, ULONG IoctlCode,
+    WDF_MEMORY_DESCRIPTOR* inputDesc, WDF_MEMORY_DESCRIPTOR* outputDesc,
+    WDF_REQUEST_SEND_OPTIONS* RequestOptions, ULONG_PTR* BytesReturned) {
+    WDFMEMORY input = 0;
+    if (inputDesc) {
+        ASSERTMSG("Input buffer type not WdfMemoryDescriptorTypeBuffer", inputDesc->Type == WdfMemoryDescriptorTypeBuffer);
+        void* inputPtr = inputDesc->u.BufferType.Buffer;
+        size_t inputLength = inputDesc->u.BufferType.Length;
+
+        NTSTATUS status = WdfMemoryCreatePreallocated(WDF_NO_OBJECT_ATTRIBUTES, inputPtr, inputLength, &input);
+        if (!NT_SUCCESS(status)) {
+            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("TailLight: WdfMemoryCreatePreallocated input failed 0x%x"), status);
+            return status;
+        }
+    }
+
+    WDFMEMORY output = 0;
+    if (outputDesc) {
+        ASSERTMSG("Output buffer type not WdfMemoryDescriptorTypeBuffer", outputDesc->Type == WdfMemoryDescriptorTypeBuffer);
+        void* outputPtr = outputDesc->u.BufferType.Buffer;
+        size_t outputLength = outputDesc->u.BufferType.Length;
+
+        NTSTATUS status = WdfMemoryCreatePreallocated(WDF_NO_OBJECT_ATTRIBUTES, outputPtr, outputLength, &output);
+        if (!NT_SUCCESS(status)) {
+            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("TailLight: WdfMemoryCreatePreallocated output failed 0x%x"), status);
+            return status;
+        }
+    }
+
+    bool requestCreated = false;
+    if (!request) {
+        NTSTATUS status = WdfRequestCreate(WDF_NO_OBJECT_ATTRIBUTES, target, &request);
+        if (!NT_SUCCESS(status)) {
+            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("TailLight: WdfRequestCreate failed 0x%x"), status);
+        }
+        ASSERTMSG("TailLight: WdfRequestCreate failed", NT_SUCCESS(status));
+        requestCreated = true;
+    }
+
+    NTSTATUS status = WdfIoTargetFormatRequestForIoctl(target, request, IoctlCode, input, NULL, output, NULL);
+    if (!NT_SUCCESS(status)) {
+        DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("TailLight: WdfIoTargetFormatRequestForIoctl failed 0x%x"), status);
+    }
+    ASSERTMSG("TailLight: WdfIoTargetFormatRequestForIoctl failed", NT_SUCCESS(status));
+
+#if 0
+    {
+        // WIP: propagate FileObject permissions
+        IRP* irp = WdfRequestWdmGetIrp(request);
+        IO_STACK_LOCATION* curStack = IoGetCurrentIrpStackLocation(irp);
+        IO_STACK_LOCATION* nextStack = IoGetNextIrpStackLocation(irp);
+        ASSERTMSG("TailLight: FileObject null", curStack->FileObject);
+
+        nextStack->FileObject = curStack->FileObject;
+    }
+#endif
+
+    BOOLEAN ret = FALSE;
+    if (RequestOptions) {
+        RequestOptions->Flags |= WDF_REQUEST_SEND_OPTION_SYNCHRONOUS; // force synchronous behavior
+
+        ret = WdfRequestSend(request, target, RequestOptions);
+    }
+    else {
+        WDF_REQUEST_SEND_OPTIONS defaultOptions{};
+        WDF_REQUEST_SEND_OPTIONS_INIT(&defaultOptions, WDF_REQUEST_SEND_OPTION_SYNCHRONOUS);
+
+        ret = WdfRequestSend(request, target, &defaultOptions);
+    }
+    status = WdfRequestGetStatus(request); // can check status immediately when WDF_REQUEST_SEND_OPTION_SYNCHRONOUS is set
+    if ((ret == FALSE) || !NT_SUCCESS(status)) {
+        DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("TailLight: WdfRequestSend failed 0x%x"), status);
+        return status;
+    }
+
+    if (BytesReturned)
+        *BytesReturned = WdfRequestGetInformation(request);
+
+    // delete objects in reverse order
+    // TODO: Protect against leaks on early returns
+    if (requestCreated)
+        WdfObjectDelete(request);
+    if (output)
+        WdfObjectDelete(output);
+    if (input)
+        WdfObjectDelete(input);
+
+    return STATUS_SUCCESS;
+}
+
 /** Blocking IOCTL_HID_GET_FEATURE request with pre-populated report. */
 NTSTATUS GetFeatureReport(WDFIOTARGET target, UCHAR reportId) {
     if (!reportId)

--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -28,9 +28,9 @@ static void UpdateBatteryState(BATT_STATE& state, HIDP_REPORT_TYPE reportType, C
 
         auto CycleCountBefore = state.BatteryInfo.CycleCount;
 
-        WdfWaitLockAcquire(state.Lock, nullptr);
+        WdfSpinLockAcquire(state.Lock);
         state.BatteryInfo.CycleCount = value;
-        WdfWaitLockRelease(state.Lock);
+        WdfSpinLockRelease(state.Lock);
 
         if (state.BatteryInfo.CycleCount != CycleCountBefore) {
             DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Updating HID CycleCount before=%u, after=%u\n", CycleCountBefore, state.BatteryInfo.CycleCount);
@@ -47,10 +47,10 @@ static void UpdateBatteryState(BATT_STATE& state, HIDP_REPORT_TYPE reportType, C
 
         auto TempBefore = state.Temperature;
 
-        WdfWaitLockAcquire(state.Lock, nullptr);
+        WdfSpinLockAcquire(state.Lock);
         // convert HID PD unit from (Kelvin) to BATTERY_QUERY_INFORMATION unit (10ths of a degree Kelvin)
         state.Temperature = 10*value;
-        WdfWaitLockRelease(state.Lock);
+        WdfSpinLockRelease(state.Lock);
 
         if (state.Temperature != TempBefore) {
             DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Updating HID Temperature before=%u, after=%u\n", TempBefore, state.Temperature);

--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -26,7 +26,18 @@ static void UpdateBatteryState(BATT_STATE& state, HIDP_REPORT_TYPE reportType, C
     }
 
     // capture shared state
-    if (code == CycleCount_Code) {
+    if (code == Temperature_Code) {
+         auto TempBefore = state.Temperature;
+
+         WdfSpinLockAcquire(state.Lock);
+         // convert HID PD unit from (Kelvin) to BATTERY_QUERY_INFORMATION unit (10ths of a degree Kelvin)
+         state.Temperature = 10 * value;
+         WdfSpinLockRelease(state.Lock);
+
+         if (state.Temperature != TempBefore) {
+             DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Updating HID Temperature before=%u, after=%u\n", TempBefore, state.Temperature);
+         }
+     } else if (code == CycleCount_Code) {
         auto CycleCountBefore = state.BatteryInfo.CycleCount;
 
         WdfSpinLockAcquire(state.Lock);
@@ -35,17 +46,6 @@ static void UpdateBatteryState(BATT_STATE& state, HIDP_REPORT_TYPE reportType, C
 
         if (state.BatteryInfo.CycleCount != CycleCountBefore) {
             DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Updating HID CycleCount before=%u, after=%u\n", CycleCountBefore, state.BatteryInfo.CycleCount);
-        }
-    } else if (code == Temperature_Code) {
-        auto TempBefore = state.Temperature;
-
-        WdfSpinLockAcquire(state.Lock);
-        // convert HID PD unit from (Kelvin) to BATTERY_QUERY_INFORMATION unit (10ths of a degree Kelvin)
-        state.Temperature = 10*value;
-        WdfSpinLockRelease(state.Lock);
-
-        if (state.Temperature != TempBefore) {
-            DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Updating HID Temperature before=%u, after=%u\n", TempBefore, state.Temperature);
         }
     }
 }

--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -274,6 +274,10 @@ NTSTATUS GetStandardStringReport(WDFIOTARGET target, ULONG ioctl, wchar_t (&buff
 
 NTSTATUS InitializeHidState(_In_ WDFDEVICE Device) {
     DEVICE_CONTEXT* context = WdfObjectGet_DEVICE_CONTEXT(Device);
+
+    WDFIOTARGET localTarget = WdfDeviceGetIoTarget(Device);
+    UNREFERENCED_PARAMETER(localTarget);
+
     WDFIOTARGET_Wrap pdoTarget;
     {
         // Use PDO for HID commands instead of local IO target to avoid 0xc0000061 (STATUS_PRIVILEGE_NOT_HELD) on IOCTL_HID_SET_FEATURE

--- a/HidBattExt/HidPd.hpp
+++ b/HidBattExt/HidPd.hpp
@@ -25,6 +25,6 @@ private:
 };
 
 
-NTSTATUS InitializeHidState(_In_ WDFDEVICE Device);
+NTSTATUS InitializeHidState(_In_ WDFDEVICE Device, WDFIOTARGET pdoTarget);
 
 EVT_WDF_IO_QUEUE_IO_READ           EvtIoReadHidFilter;

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -173,8 +173,6 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
     // Driver Framework always zero initializes an objects context memory
     DEVICE_CONTEXT* deviceContext = WdfObjectGet_DEVICE_CONTEXT(Device);
 
-    deviceContext->LowState.Initialize(Device);
-
     {
         // initialize DEVICE_CONTEXT struct with PdoName
         deviceContext->PdoName = GetTargetPropertyString(WdfDeviceGetIoTarget(Device), DevicePropertyPhysicalDeviceObjectName);

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -17,8 +17,7 @@ _Function_class_(EVT_WDF_DEVICE_SELF_MANAGED_IO_INIT)
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS EvtSelfManagedIoInit(WDFDEVICE Device) {
-    UNREFERENCED_PARAMETER(Device);
-    NTSTATUS status = InitializeBattery(Device);
+    NTSTATUS status = InitializeBatteryClass(Device);
     if (!NT_SUCCESS(status)) {
         DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: InitializeBattery failed 0x%x"), status);
         return status;
@@ -35,6 +34,8 @@ void EvtSelfManagedIoCleanup(WDFDEVICE Device) {
     UNREFERENCED_PARAMETER(Device);
 
     DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Device removed FDO(0x%p)\n", WdfDeviceWdmGetDeviceObject(Device));
+
+    UnloadBatteryClass(Device);
 }
 
 

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -6,12 +6,10 @@
 
 _Use_decl_annotations_
 NTSTATUS EvtPrepareHardware(WDFDEVICE Device, WDFCMRESLIST ResourcesRaw, WDFCMRESLIST ResourcesTranslated) {
-    UNREFERENCED_PARAMETER(Device);
     UNREFERENCED_PARAMETER(ResourcesRaw);
     UNREFERENCED_PARAMETER(ResourcesTranslated);
-#if 0
+
     InitializeBatteryState(Device);
-#endif
     return STATUS_SUCCESS;
 }
 
@@ -19,14 +17,12 @@ _Function_class_(EVT_WDF_DEVICE_SELF_MANAGED_IO_INIT)
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS EvtSelfManagedIoInit(WDFDEVICE Device) {
-    UNREFERENCED_PARAMETER(Device);
-#if 0
     NTSTATUS status = InitializeBatteryClass(Device);
     if (!NT_SUCCESS(status)) {
         DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: InitializeBattery failed 0x%x"), status);
         return status;
     }
-#endif
+
     return STATUS_SUCCESS;
 }
 
@@ -205,7 +201,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
     }
 
     {
-#if 0
+#if 1
         // Register WDM preprocess callbacks for IRP_MJ_DEVICE_CONTROL and
         // IRP_MJ_SYSTEM_CONTROL. The battery class driver needs to handle these IO
         // requests directly.

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -204,7 +204,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
         WDF_OBJECT_ATTRIBUTES_INIT(&LockAttributes);
         LockAttributes.ParentObject = Device;
 
-        status = WdfWaitLockCreate(&LockAttributes, &deviceContext->StateLock);
+        status = WdfWaitLockCreate(&LockAttributes, &deviceContext->State.Lock);
         if (!NT_SUCCESS(status)) {
             DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("WdfWaitLockCreate(StateLock) Failed. Status 0x%x"), status);
             return status;

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -183,14 +183,12 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
         }
     }
 
-    if (deviceContext->Mode == FilterMode::Lower) {
-        // subscribe to PnP events for deferred HID PDO opening
-        NTSTATUS status = IoRegisterPlugPlayNotification(EventCategoryDeviceInterfaceChange, PNPNOTIFY_DEVICE_INTERFACE_INCLUDE_EXISTING_INTERFACES, (PVOID)&GUID_DEVINTERFACE_HID,
-                                                         WdfDriverWdmGetDriverObject(WdfDeviceGetDriver(Device)), EvhHidInterfaceChange, (PVOID)deviceContext, &deviceContext->NotificationHandle);
-        if (!NT_SUCCESS(status)) {
-            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: IoRegisterPlugPlayNotification failed: 0x%x"), status);
-            return status;
-        }
+    // subscribe to PnP events for deferred HID PDO opening
+    NTSTATUS status = IoRegisterPlugPlayNotification(EventCategoryDeviceInterfaceChange, PNPNOTIFY_DEVICE_INTERFACE_INCLUDE_EXISTING_INTERFACES, (PVOID)&GUID_DEVINTERFACE_HID,
+                                                        WdfDriverWdmGetDriverObject(WdfDeviceGetDriver(Device)), EvhHidInterfaceChange, (PVOID)deviceContext, &deviceContext->NotificationHandle);
+    if (!NT_SUCCESS(status)) {
+        DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: IoRegisterPlugPlayNotification failed: 0x%x"), status);
+        return status;
     }
 
     return STATUS_SUCCESS;

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -161,13 +161,13 @@ NTSTATUS EvhHidInterfaceChange(_In_ void* NotificationStruct, _Inout_opt_ void* 
         FILE_OBJECT* file = WdfIoTargetWdmGetTargetFileObject(newDev);
         DebugPrint(DPFLTR_WARNING_LEVEL, "HidBattExt: EvhHidInterfaceChange FsContext=%p, FsContext2=%p\n", file->FsContext, file->FsContext2);
 #endif
+
+        // unsubscribe from additional PnP events
+        IoUnregisterPlugPlayNotificationEx(deviceContext->NotificationHandle);
+        deviceContext->NotificationHandle = nullptr;
+
+        InitializeHidState(device, newDev);
     }
-
-    // unsubscribe from additional PnP events
-    IoUnregisterPlugPlayNotificationEx(deviceContext->NotificationHandle);
-    deviceContext->NotificationHandle = nullptr;
-
-    InitializeHidState(device);
 
     return STATUS_SUCCESS;
 }

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -202,7 +202,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
         WDF_OBJECT_ATTRIBUTES_INIT(&LockAttributes);
         LockAttributes.ParentObject = Device;
 
-        status = WdfWaitLockCreate(&LockAttributes, &deviceContext->State.Lock);
+        status = WdfSpinLockCreate(&LockAttributes, &deviceContext->State.Lock);
         if (!NT_SUCCESS(status)) {
             DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("WdfWaitLockCreate(StateLock) Failed. Status 0x%x"), status);
             return status;

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -118,7 +118,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
     UNREFERENCED_PARAMETER(Driver);
 
     // Configure the device as a filter driver
-    WdfFdoInitSetFilter(DeviceInit);
+    //WdfFdoInitSetFilter(DeviceInit);
 
     {
         // register PnP callbacks (must be done before WdfDeviceCreate)

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -1,6 +1,6 @@
+#include "Battery.hpp"
 #include "device.hpp"
 #include <Hidport.h>
-#include "Battery.hpp"
 #include "HidPd.hpp"
 
 

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -102,6 +102,11 @@ NTSTATUS EvhHidInterfaceChange(_In_ void* NotificationStruct, _Inout_opt_ void* 
         }
 
         DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: EvhHidInterfaceChange opening %wZ\n", &devPdo);
+
+#if DBG
+        FILE_OBJECT* file = WdfIoTargetWdmGetTargetFileObject(newDev);
+        DebugPrint(DPFLTR_WARNING_LEVEL, "HidBattExt: EvhHidInterfaceChange FsContext=%p, FsContext2=%p\n", file->FsContext, file->FsContext2);
+#endif
     }
 
     // unsubscribe from additional PnP events

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -140,29 +140,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
     // Driver Framework always zero initializes an objects context memory
     DEVICE_CONTEXT* deviceContext = WdfObjectGet_DEVICE_CONTEXT(Device);
 
-    if (WdfDeviceWdmGetPhysicalDevice(Device) == WdfDeviceWdmGetAttachedDevice(Device)) {
-        DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Running as Lower filter driver below HidBatt\n");
-
-        deviceContext->Mode = FilterMode::Lower;
-
-        deviceContext->LowState.Initialize(Device);
-
-        NTSTATUS status = deviceContext->Interface.Register(Device, deviceContext->LowState);
-        if (!NT_SUCCESS(status)) {
-            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfDeviceAddQueryInterface error %x"), status);
-            return status;
-        }
-    } else {
-        DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: Running as Upper filter driver above HidBatt\n");
-
-        deviceContext->Mode = FilterMode::Upper;
-
-        NTSTATUS status = deviceContext->Interface.Lookup(Device);
-        if (!NT_SUCCESS(status)) {
-            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfFdoQueryForInterface error %x"), status);
-            return status;
-        }
-    }
+    deviceContext->LowState.Initialize(Device);
 
     {
         // initialize DEVICE_CONTEXT struct with PdoName
@@ -175,23 +153,11 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
         DebugPrint(DPFLTR_INFO_LEVEL, "HidBattExt: PdoName: %wZ\n", deviceContext->PdoName); // outputs "\Device\00000083"
     }
 
-    if (deviceContext->Mode == FilterMode::Lower) {
+    {
         // create queue for filtering HID Power Device requests
         WDF_IO_QUEUE_CONFIG queueConfig = {};
         WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
         queueConfig.EvtIoRead = EvtIoReadHidFilter; // filter read requests
-
-        WDFQUEUE queue = 0; // auto-deleted when "Device" is deleted
-        NTSTATUS status = WdfIoQueueCreate(Device, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, &queue);
-        if (!NT_SUCCESS(status)) {
-            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: WdfIoQueueCreate failed 0x%x"), status);
-            return status;
-        }
-    } else if (deviceContext->Mode == FilterMode::Upper) {
-        // create queue for filtering Battery device requests
-        WDF_IO_QUEUE_CONFIG queueConfig = {};
-        WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
-        queueConfig.EvtIoDeviceControl = EvtIoDeviceControlBattFilter; // filter IOCTL requests
 
         WDFQUEUE queue = 0; // auto-deleted when "Device" is deleted
         NTSTATUS status = WdfIoQueueCreate(Device, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, &queue);

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -146,15 +146,6 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
         }
     }
 
-    {
-        // reserve context space for request objects
-        WDF_OBJECT_ATTRIBUTES attr{};
-        WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attr, REQUEST_CONTEXT);
-
-        WdfDeviceInitSetRequestAttributes(DeviceInit, &attr);
-    }
-
-
     WDFDEVICE Device = 0;
     {
         // create device

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -171,6 +171,31 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
     }
 
     {
+        // initialize battery fields
+        deviceContext->BatteryTag = BATTERY_TAG_INVALID;
+        deviceContext->ClassHandle = NULL;
+
+        WDF_OBJECT_ATTRIBUTES LockAttributes{};
+        WDF_OBJECT_ATTRIBUTES_INIT(&LockAttributes);
+        LockAttributes.ParentObject = Device;
+
+        NTSTATUS status = WdfWaitLockCreate(&LockAttributes, &deviceContext->ClassInitLock);
+        if (!NT_SUCCESS(status)) {
+            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("WdfWaitLockCreate(ClassInitLock) Failed. Status 0x%x"), status);
+            return status;
+        }
+
+        WDF_OBJECT_ATTRIBUTES_INIT(&LockAttributes);
+        LockAttributes.ParentObject = Device;
+
+        status = WdfWaitLockCreate(&LockAttributes, &deviceContext->StateLock);
+        if (!NT_SUCCESS(status)) {
+            DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("WdfWaitLockCreate(StateLock) Failed. Status 0x%x"), status);
+            return status;
+        }
+    }
+
+    {
         // create queue for filtering HID Power Device requests
         WDF_IO_QUEUE_CONFIG queueConfig = {};
         WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -6,10 +6,12 @@
 
 _Use_decl_annotations_
 NTSTATUS EvtPrepareHardware(WDFDEVICE Device, WDFCMRESLIST ResourcesRaw, WDFCMRESLIST ResourcesTranslated) {
+    UNREFERENCED_PARAMETER(Device);
     UNREFERENCED_PARAMETER(ResourcesRaw);
     UNREFERENCED_PARAMETER(ResourcesTranslated);
-
+#if 0
     InitializeBatteryState(Device);
+#endif
     return STATUS_SUCCESS;
 }
 
@@ -17,12 +19,14 @@ _Function_class_(EVT_WDF_DEVICE_SELF_MANAGED_IO_INIT)
 _IRQL_requires_same_
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS EvtSelfManagedIoInit(WDFDEVICE Device) {
+    UNREFERENCED_PARAMETER(Device);
+#if 0
     NTSTATUS status = InitializeBatteryClass(Device);
     if (!NT_SUCCESS(status)) {
         DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("HidBattExt: InitializeBattery failed 0x%x"), status);
         return status;
     }
-
+#endif
     return STATUS_SUCCESS;
 }
 
@@ -201,6 +205,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
     }
 
     {
+#if 0
         // Register WDM preprocess callbacks for IRP_MJ_DEVICE_CONTROL and
         // IRP_MJ_SYSTEM_CONTROL. The battery class driver needs to handle these IO
         // requests directly.
@@ -214,6 +219,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
             DebugPrint(DPFLTR_ERROR_LEVEL, DML_ERR("WdfDeviceInitAssignWdmIrpPreprocessCallback(IRP_MJ_DEVICE_CONTROL) Failed. 0x%x"), status);
             return status;
         }
+#endif
     }
 
     WDFDEVICE Device = 0;

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -65,7 +65,7 @@ struct DEVICE_CONTEXT {
     // Battery class registration
     void*              ClassHandle;
     WDFWAITLOCK        ClassInitLock;
-    //WMILIB_CONTEXT     WmiLibContext;
+    WMILIB_CONTEXT     WmiLibContext;
 
     // Battery state
     WDFWAITLOCK        StateLock;

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -38,6 +38,7 @@ static constexpr HidCode RemainingCapacity_Code = { 0x85, 0x66 };
 static constexpr HidCode DesignCapacity_Code = { 0x85, 0x83 };
 static constexpr HidCode FullCapacity_Code = { 0x85, 0x67 };
 static constexpr HidCode Voltage_Code = { 0x84, 0x30 };
+static constexpr HidCode RunTimeToEmpty_Code = { 0x85, 0x68 };
 
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -57,16 +57,3 @@ struct DEVICE_CONTEXT {
     BATT_STATE         State;
 };
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)
-
-
-/** IOCTL buffer object to allow completion routines to access request information. */
-struct REQUEST_CONTEXT {
-    ULONG IoControlCode = 0;
-    ULONG InformationLevel = 0; // contains BATTERY_QUERY_INFORMATION::InformationLevel in IOCTL_BATTERY_QUERY_INFORMATION requests
-
-    void Set(ULONG ioctl, ULONG infoLevel) {
-        IoControlCode = ioctl;
-        InformationLevel = infoLevel;
-    }
-};
-WDF_DECLARE_CONTEXT_TYPE(REQUEST_CONTEXT)

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -68,7 +68,6 @@ struct DEVICE_CONTEXT {
     WMILIB_CONTEXT     WmiLibContext;
 
     // Battery state
-    WDFWAITLOCK        StateLock;
     ULONG              BatteryTag;
     BATT_STATE         State;
 };

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "driver.hpp"
 #include <hidpddi.h> // for PHIDP_PREPARSED_DATA
+#include "Battery.hpp"
 
 
 struct HidCode {
@@ -60,6 +61,16 @@ struct DEVICE_CONTEXT {
     HidConfig      Hid;       // for lower filter usage
     BatteryState   LowState;  // lower filter instance state (not directly accessible from upper filter)
     void*          NotificationHandle; // opaque value to identify PnP notification registration
+
+    // Battery class registration
+    void*              ClassHandle;
+    WDFWAITLOCK        ClassInitLock;
+    //WMILIB_CONTEXT     WmiLibContext;
+
+    // Battery state
+    WDFWAITLOCK        StateLock;
+    ULONG              BatteryTag;
+    BATT_STATE         State;
 };
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)
 

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -26,8 +26,7 @@ struct HidConfig {
     USHORT InputReportByteLength = 0;
     USHORT FeatureReportByteLength = 0;
 
-    UCHAR TemperatureReportID = 0;
-    UCHAR CycleCountReportID = 0;
+    HidCode reports[256] = {}; // ReportID lookup
 
     LONG Initialized = 0; // struct initialized (atomic value)
 };

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -8,8 +8,10 @@ struct HidCode {
     USAGE UsagePage = 0;
     USAGE Usage = 0;
 
+    bool button = 0; // is a button
+
     bool operator ==(HidCode other) const {
-        return (other.UsagePage == UsagePage) && (other.Usage == Usage);
+        return (other.UsagePage == UsagePage) && (other.Usage == Usage); // "button" deliberately not checked
     }
 };
 
@@ -43,6 +45,12 @@ static constexpr HidCode ManufacturerDate_Code = {0x85, 0x85};
 static constexpr HidCode Chemistry_Code = { 0x85, 0x89 };
 static constexpr HidCode Manufacturer_Code = { 0x84, 0xFD };
 static constexpr HidCode SerialNumber_Code = { 0x84, 0xFF };
+// PresentStatus fields
+static constexpr HidCode PresentStatus_Code = { 0x84, 0x02 }; // whole collection
+static constexpr HidCode Charging_Code = { 0x85, 0x44 };
+static constexpr HidCode Discharging_Code = { 0x85, 0x45 };
+static constexpr HidCode ACPresent_Code = { 0x85, 0xD0 };
+static constexpr HidCode ShutdownImminent_Code = { 0x84, 0x69 };
 
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -37,6 +37,7 @@ static constexpr HidCode CycleCount_Code = { 0x85, 0x6B }; // from 4.2 Battery S
 static constexpr HidCode RemainingCapacity_Code = { 0x85, 0x66 };
 static constexpr HidCode DesignCapacity_Code = { 0x85, 0x83 };
 static constexpr HidCode FullCapacity_Code = { 0x85, 0x67 };
+static constexpr HidCode Voltage_Code = { 0x84, 0x30 };
 
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -37,29 +37,10 @@ static constexpr HidCode Temperature_Code = { 0x84, 0x36 }; // from 4.1 Power De
 static constexpr HidCode CycleCount_Code = { 0x85, 0x6B }; // from 4.2 Battery System Page (x85) Table 3.
 
 
-/** Battery parameters shared between Upper and Lower filter driver instances. */
-class BatteryState {
-public:
-    WDFSPINLOCK Lock = 0;  // to protext member access
-
-    ULONG CycleCount = 0;  // BATTERY_INFORMATION::CycleCount value
-    ULONG Temperature = 0; // IOCTL_BATTERY_QUERY_INFORMATION BatteryTemperature value
-
-    void Initialize(WDFDEVICE device) {
-        WDF_OBJECT_ATTRIBUTES attr{};
-        WDF_OBJECT_ATTRIBUTES_INIT(&attr);
-        attr.ParentObject = device; // auto-deleted when "device" is deleted
-
-        NTSTATUS status = WdfSpinLockCreate(&attr, &Lock);
-        NT_ASSERTMSG("WdfSpinLockCreate failed.\n", status == STATUS_SUCCESS); status;
-    }
-};
-
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {
     UNICODE_STRING PdoName;
     HidConfig      Hid;       // for lower filter usage
-    BatteryState   LowState;  // lower filter instance state (not directly accessible from upper filter)
     void*          NotificationHandle; // opaque value to identify PnP notification registration
 
     // Battery class registration

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -41,6 +41,8 @@ static constexpr HidCode Voltage_Code = { 0x84, 0x30 };
 static constexpr HidCode RunTimeToEmpty_Code = { 0x85, 0x68 };
 static constexpr HidCode ManufacturerDate_Code = {0x85, 0x85};
 static constexpr HidCode Chemistry_Code = { 0x85, 0x89 };
+static constexpr HidCode Manufacturer_Code = { 0x84, 0xFD };
+static constexpr HidCode SerialNumber_Code = { 0x84, 0xFF };
 
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -40,6 +40,7 @@ static constexpr HidCode FullCapacity_Code = { 0x85, 0x67 };
 static constexpr HidCode Voltage_Code = { 0x84, 0x30 };
 static constexpr HidCode RunTimeToEmpty_Code = { 0x85, 0x68 };
 static constexpr HidCode ManufacturerDate_Code = {0x85, 0x85};
+static constexpr HidCode Chemistry_Code = { 0x85, 0x89 };
 
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -34,7 +34,9 @@ struct HidConfig {
 /** HID Power Device report UsagePage and Usage codes from https://www.usb.org/sites/default/files/pdcv11.pdf */
 static constexpr HidCode Temperature_Code = { 0x84, 0x36 }; // from 4.1 Power Device Page (x84) Table 2.
 static constexpr HidCode CycleCount_Code = { 0x85, 0x6B }; // from 4.2 Battery System Page (x85) Table 3.
-
+static constexpr HidCode RemainingCapacity_Code = { 0x85, 0x66 };
+static constexpr HidCode DesignCapacity_Code = { 0x85, 0x83 };
+static constexpr HidCode FullCapacity_Code = { 0x85, 0x67 };
 
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -39,6 +39,7 @@ static constexpr HidCode DesignCapacity_Code = { 0x85, 0x83 };
 static constexpr HidCode FullCapacity_Code = { 0x85, 0x67 };
 static constexpr HidCode Voltage_Code = { 0x84, 0x30 };
 static constexpr HidCode RunTimeToEmpty_Code = { 0x85, 0x68 };
+static constexpr HidCode ManufacturerDate_Code = {0x85, 0x85};
 
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {

--- a/HidBattExt/device.hpp
+++ b/HidBattExt/device.hpp
@@ -3,11 +3,6 @@
 #include <hidpddi.h> // for PHIDP_PREPARSED_DATA
 
 
-enum class FilterMode {
-    Upper, // Running above HidBatt. Filters (modifies) battery IOCTL communication.
-    Lower, // Running below HidBatt. Filters (parses) HID Power Device communication.
-};
-
 struct HidCode {
     USAGE UsagePage = 0;
     USAGE Usage = 0;
@@ -59,53 +54,11 @@ public:
     }
 };
 
-DEFINE_GUID(GUID_HIDBATTEXT_SHARED_STATE, 0x2f52277a, 0x88f8, 0x44f3, 0x87, 0xec, 0x48, 0xb2, 0xe9, 0x51, 0x84, 0x58);
-
-/** State to share between Upper and Lower filter driver instances. */
-struct HidBattExtIf : public INTERFACE {
-    BatteryState* State = nullptr; // non-owning ptr.
-
-    HidBattExtIf() {
-        // clear all INTERFACE members
-        Size = 0;
-        Version = 0;
-        Context = 0;
-        InterfaceReference = nullptr;
-        InterfaceDereference = nullptr;
-    }
-
-    /** Register this object so that it can be looked up by other driver instances. */
-    NTSTATUS Register (WDFDEVICE device, BatteryState& state) {
-        // initialize INTERFACE header
-        Size = sizeof(HidBattExtIf);
-        Version = 1;
-        Context = device;
-        // Let the framework handle reference counting
-        InterfaceReference = WdfDeviceInterfaceReferenceNoOp;
-        InterfaceDereference = WdfDeviceInterfaceDereferenceNoOp;
-
-        // initialize shared state ptr.
-        State = &state;
-
-        // register device interface, so that other driver instances can detect it
-        WDF_QUERY_INTERFACE_CONFIG  cfg{};
-        WDF_QUERY_INTERFACE_CONFIG_INIT(&cfg, this, &GUID_HIDBATTEXT_SHARED_STATE, NULL);
-        return WdfDeviceAddQueryInterface(device, &cfg);
-    }
-
-    /** Lookup state from other driver instance in same driver stack. WILL OVERWRITE all fields in this object. */
-    NTSTATUS Lookup(WDFDEVICE device) {
-        return WdfFdoQueryForInterface(device, &GUID_HIDBATTEXT_SHARED_STATE, this, sizeof(HidBattExtIf), 1, NULL);
-    }
-};
-
 /** Driver-specific struct for storing instance-specific data. */
 struct DEVICE_CONTEXT {
-    FilterMode     Mode;      // upper or lower driver instance
     UNICODE_STRING PdoName;
     HidConfig      Hid;       // for lower filter usage
     BatteryState   LowState;  // lower filter instance state (not directly accessible from upper filter)
-    HidBattExtIf   Interface; // for communication between driver instances
     void*          NotificationHandle; // opaque value to identify PnP notification registration
 };
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)


### PR DESCRIPTION
Modifications to convert the driver from a _filter_ to a _function_ driver. The driver is able to retrieve initial values, but **INPUT report handling doesn't work**. 

### To investigate
* `Hidclass` (hidclass.sys): continuously reads from the usb device
* `HidUsb`: Transport driver / HID minidriver

Links:
* [HIDUSBFX2 sample driver](https://github.com/microsoft/Windows-driver-samples/tree/main/hid/hidusbfx2)
* [HID Minidriver Sample](https://github.com/microsoft/Windows-driver-samples/tree/main/hid/vhidmini2) UMDF & KMDF
* [Creating WDF HID Minidrivers](https://learn.microsoft.com/en-us/windows-hardware/drivers/wdf/creating-umdf-hid-minidrivers): Write a lower filter driver under `MsHidKmdf.sys` (Win11) or `hidkmdf.sys` from hidusbfx2 (Win10)
* [HID architecture](https://learn.microsoft.com/en-us/windows-hardware/drivers/hid/hid-architecture)

### Device stack
![image](https://github.com/user-attachments/assets/a7a89423-9c10-41ae-b54a-b87b7dba90e3)

## Problems if removing `WdfFdoInitSetFilter(DeviceInit)`
Driver load error:
```
HidBattExt: DriverEntry
HidBattExt: Device added PDO(0xFFFFBF8B88E1E060) FDO(0xFFFFBF8B8875A4E0), Lower(0xFFFFBF8B88E1E060)
HidBattExt: PdoName: \Device\0000003a
Entering InitializeHidStateTimer
HidBattExt: ProductID=8037, VendorID=2341, VersionNumber=256, DescriptorSize=3108
HidBattExt: Usage=4, UsagePage=84, InputReportByteLength=3, FeatureReportByteLength=3
HidBattExt: CycleCount ReportID is 0x14
HidBattExt: Temperature ReportID is 0xa
HidBattExt: IOCTL_HID_GET_FEATURE failed 0xc0000010 (STATUS_INVALID_DEVICE_REQUEST)
```


Error if instead calling `IOCTL_HID_GET_FEATURE ` with default IO target:
```
HidBattExt: IOCTL_HID_GET_FEATURE failed 0xc0000061 (STATUS_PRIVILEGE_NOT_HELD)
```

Related to https://github.com/forderud/IntelliMouseDriver/issues/87, https://github.com/forderud/IntelliMouseDriver/issues/90

Error when attempting to forward `EvtDeviceFileCreate` request:
```
HidBattExt: WdfRequestSend failed with status: 0xc0000010 (STATUS_INVALID_DEVICE_REQUEST)
```

### Ideas
* [STATUS_PRIVILEGE_NOT_HELD](https://community.osr.com/t/status-privilege-not-held/48267): `FsContext` is allocated and setup by HIDCLASS in MJ_CREATE processing
* [STATUS_PRIVILEGE_NOT_HELD while sending IOCTL_HID_GET_FEATURE from KMDF HID client](https://community.osr.com/t/status-privilege-not-held-while-sending-ioctl-hid-get-feature-from-kmdf-hid-client/53010): Suggestion: Add EvtDeviceFileCreate callback; `IRP* irp = WdfRequestWdmGetIrp(request); IoGetNextIrpStackLocation(irp)->FileObject = IoGetCurrentIrpStackLocation(irp)->FileObject;`
* https://www.osr.com/nt-insider/2014-issue1/wdf-file-object-callbacks-properties-demystified/
* [WdfRequestSend when formatted for Read returns STATUS_PRIVILEDGE_NOT_HELD](https://community.osr.com/t/wdfrequestsend-when-formatted-for-read-returns-status-priviledge-not-held-even-though-prior-wdfreque/52554): Suggestion: "modify the privileges in EvtDeviceFileCreate".

Documentation:
* [WdfDeviceInitSetFileObjectConfig](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdeviceinitsetfileobjectconfig)
* [WdfRequestGetFileObject](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdfrequest/nf-wdfrequest-wdfrequestgetfileobject)
* [WdfFileObjectWdmGetFileObject](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdffileobject/nf-wdffileobject-wdffileobjectwdmgetfileobject)
* [FILE_OBJECT](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_file_object): Investigate `FsContext` & `ReadAccess` fields
