### PR TITLE
Try to reproduce "critical thermal event" (doesn't work)

### DIFF
--- a/battery/battery.ino
+++ b/battery/battery.ino
@@ -21,7 +21,7 @@ uint16_t Voltage =1499; // centiVolt
 uint16_t RunTimeToEmpty = 0; // maps to BatteryEstimatedTime on Windows
 uint16_t ManufacturerDate = 0; // initialized in setup function
 int16_t  CycleCount = 41;
-uint16_t Temperature = 300; // degrees Kelvin
+uint16_t Temperature = 999; // degrees Kelvin
 
 // Parameters for ACPI compliancy
 const uint16_t DesignCapacity = 58003*360/Voltage; // AmpSec=mWh*360/centiVolt (1 mAh = 3.6 As)
@@ -133,6 +133,8 @@ void loop() {
   } else {
     PresentStatus.ShutdownImminent = 0;
   }
+
+  PresentStatus.ShutdownImminent = true;
 
   //************ Delay ****************************************
   delay(1000);

--- a/src/HIDPowerDevice.h
+++ b/src/HIDPowerDevice.h
@@ -50,4 +50,4 @@ private:
 };
 
 // max number of batteries supported by the HW
-#define MAX_BATTERIES (USB_ENDPOINTS - CDC_FIRST_ENDPOINT - CDC_ENPOINT_COUNT) // 3 by default; 6 if defining CDC_DISABLED in %LOCALAPPDATA%\Arduino15\packages\arduino\hardware\avr\<version>\cores\arduino\USBDesc.h
+#define MAX_BATTERIES 1


### PR DESCRIPTION
Attempt to reproduce "critical thermal event" by setting [BATTERY_STATUS](https://learn.microsoft.com/en-us/windows/win32/power/battery-status-str) `PowerState=BATTERY_CRITICAL`  and increasing cell temperature to 999 Kelvin. Still, nothing special seem to happen.

Battery parameters exposed:  
![image](https://github.com/user-attachments/assets/f7d5dc72-9594-48c6-ad5e-3a1cf8503eba)

Windows `System` events:  (only seeing "power source changed" events)  
![image](https://github.com/user-attachments/assets/f865a4b0-0e40-4b7e-9f8f-f823cec490bf)

Windows `Kernel-Power` events:  (only seeing CPU throttling events)  
![image](https://github.com/user-attachments/assets/7095d04f-7d54-45c6-91f0-33547db1213f)
