### PR TITLE
Demonstrate how to intercept & modify EvtIoRead requests (not intended for merging)

### DIFF
--- a/HidBattExt/HidPd.cpp
+++ b/HidBattExt/HidPd.cpp
@@ -237,6 +237,16 @@ void ParseReadHidBuffer(WDFDEVICE Device, _In_ WDFREQUEST Request) {
         return;
     }
 
+    // inspect & modify buffer from the battery HW
+    if (report[0] == 0x0A) { // temperature ReportID
+        // clamp unrealisticaly high temperatures
+        auto* temperature = (USHORT*)(report + 1);
+        if (*temperature > 400) {
+            *temperature = 400; // [kelvin]
+            DebugPrint(DPFLTR_WARNING_LEVEL, "HidBattExt: Clamping Temperature to %u kelvin\n", *temperature);
+        }
+    }
+
     UpdateBatteryState(context->LowState, HidP_Input, report, context->Hid);
 }
 

--- a/HidBattExt/HidPd.hpp
+++ b/HidBattExt/HidPd.hpp
@@ -28,3 +28,4 @@ private:
 NTSTATUS InitializeHidState(_In_ WDFDEVICE Device);
 
 EVT_WDF_IO_QUEUE_IO_READ           EvtIoReadHidFilter;
+EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL EvtIoctlHidFilter;

--- a/HidBattExt/device.cpp
+++ b/HidBattExt/device.cpp
@@ -173,6 +173,7 @@ NTSTATUS EvtDriverDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT Devic
         WDF_IO_QUEUE_CONFIG queueConfig = {};
         WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
         queueConfig.EvtIoRead = EvtIoReadHidFilter; // filter read requests
+        queueConfig.EvtIoDeviceControl = EvtIoctlHidFilter; // filter IOCTL requests
 
         WDFQUEUE queue = 0; // auto-deleted when "Device" is deleted
         NTSTATUS status = WdfIoQueueCreate(Device, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, &queue);


### PR DESCRIPTION
Demonstrate how to **modify temperature values received from the battery** HW by clamping values exceeding 400 Kelvin.

Needed to combine with with also filtering IOCTL_HID_GET_FEATURE requests to achieve consistency between HID INPUT (`EvtIoRead` requests) & FEATURE (`EvtIoDeviceControl` requests) reports received from the battery HW.