### PR TITLE
Don't store full PDB path in binaries

### DIFF
--- a/HidBattExt/HidBattExt.vcxproj
+++ b/HidBattExt/HidBattExt.vcxproj
@@ -82,7 +82,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -95,7 +95,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -108,7 +108,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -121,7 +121,7 @@ copy $(OutDir)\HidBattExt.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>


### PR DESCRIPTION
Follow-up to #74. Done to make the binaries more reproducible. Based on suggestions on https://nikhilism.com/post/2020/windows-deterministic-builds/

Visual diff of the generated binaries (after stripping away signatures):  
![image](https://github.com/user-attachments/assets/409613a8-a532-4997-8c54-2591a205f5a5)
